### PR TITLE
Add production environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,16 @@ jobs:
             export NEXT_PUBLIC_ENV_NAME=staging
             yarn build && yarn --production=true && npm i --prefix=$HOME/.local -g serverless && sls deploy -s staging
 
+  build-deploy-production:
+    executor: aws-cli/default
+    steps:
+      - *attach_workspace
+      - run:
+          name: deploy
+          command: |
+            export NEXT_PUBLIC_ENV_NAME=production
+            yarn build && yarn --production=true && npm i --prefix=$HOME/.local -g serverless && sls deploy -s production
+
   assume-role-development:
     executor: docker-python
     steps:
@@ -103,6 +113,19 @@ jobs:
       - checkout
       - aws_assume_role/assume_role:
           account: $AWS_ACCOUNT_STAGING
+          profile_name: default
+          role: 'LBH_Circle_CI_Deployment_Role'
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - .aws
+
+  assume-role-production:
+    executor: docker-python
+    steps:
+      - checkout
+      - aws_assume_role/assume_role:
+          account: $AWS_ACCOUNT_PRODUCTION
           profile_name: default
           role: 'LBH_Circle_CI_Deployment_Role'
       - persist_to_workspace:
@@ -146,6 +169,26 @@ workflows:
       - build-deploy-staging:
           requires:
             - assume-role-staging
+          filters:
+            branches:
+              only: main
+      - permit-deploy-production:
+          type: approval
+          requires:
+            - build-deploy-staging
+          filters:
+            branches:
+              only: main
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          requires:
+            - permit-deploy-production
+          filters:
+            branches:
+              only: main
+      - build-deploy-production:
+          requires:
+            - assume-role-production
           filters:
             branches:
               only: main

--- a/serverless.yml
+++ b/serverless.yml
@@ -100,14 +100,18 @@ custom:
   aliases:
     development: dlo-bonus-scheme-development.hackney.gov.uk
     staging: dlo-bonus-scheme-staging.hackney.gov.uk
+    production: dlo-bonus-scheme.hackney.gov.uk
   certificate-arn:
     development: arn:aws:acm:us-east-1:364864573329:certificate/d903d9e2-c3da-482b-8768-916ec09e461f
     staging: arn:aws:acm:us-east-1:087586271961:certificate/baffa134-abb5-4b71-b84f-013e9dd2d044
+    production: arn:aws:acm:us-east-1:282997303675:certificate/a43b1303-83ff-496e-b7a2-a75fa3ebfe87
   securityGroups:
     development:
       - sg-0a8a71b913edbb0ed
     staging:
       - sg-0292b24504fdce1eb
+    production:
+      - sg-064b1c3ec1577380b
   subnets:
     development:
       - subnet-0140d06fb84fdb547
@@ -115,3 +119,6 @@ custom:
     staging:
       - subnet-0ea0020a44b98a2ca
       - subnet-0743d86e9b362fa38
+    production:
+      - subnet-0beb266003a56ca82
+      - subnet-06a697d86a9b6ed01


### PR DESCRIPTION
This is required to be deployed before we can request the domain as we need to know the CloudFront distribution DNS name to alias it.
