### PR TITLE
Show scheme description instead of type

### DIFF
--- a/cypress/fixtures/operatives/electrician.json
+++ b/cypress/fixtures/operatives/electrician.json
@@ -8,7 +8,7 @@
   "section": "R3007",
   "scheme": {
     "type": "SMV",
-    "description": "SMV",
+    "description": "Reactive",
     "conversionFactor": 1.0,
     "payBands": [
       { "band": 1, "value": 2160 },

--- a/cypress/integration/operatives/non-productive-page.spec.js
+++ b/cypress/integration/operatives/non-productive-page.spec.js
@@ -89,7 +89,7 @@ describe('Non-productive page', () => {
             cy.get(':nth-child(1)').contains('Trade')
             cy.get(':nth-child(2)').contains('Electrician (EL)')
             cy.get(':nth-child(3)').contains('Scheme')
-            cy.get(':nth-child(4)').contains('SMV')
+            cy.get(':nth-child(4)').contains('Reactive')
           })
 
           cy.get('.govuk-summary-list__row:nth-child(3)').within(() => {

--- a/cypress/integration/operatives/out-of-hours-page.spec.js
+++ b/cypress/integration/operatives/out-of-hours-page.spec.js
@@ -73,7 +73,7 @@ describe('Out of hours page', () => {
             cy.get(':nth-child(1)').contains('Trade')
             cy.get(':nth-child(2)').contains('Electrician (EL)')
             cy.get(':nth-child(3)').contains('Scheme')
-            cy.get(':nth-child(4)').contains('SMV')
+            cy.get(':nth-child(4)').contains('Reactive')
           })
 
           cy.get('.govuk-summary-list__row:nth-child(3)').within(() => {

--- a/cypress/integration/operatives/productive-page.spec.js
+++ b/cypress/integration/operatives/productive-page.spec.js
@@ -89,7 +89,7 @@ describe('Productive page', () => {
             cy.get(':nth-child(1)').contains('Trade')
             cy.get(':nth-child(2)').contains('Electrician (EL)')
             cy.get(':nth-child(3)').contains('Scheme')
-            cy.get(':nth-child(4)').contains('SMV')
+            cy.get(':nth-child(4)').contains('Reactive')
           })
 
           cy.get('.govuk-summary-list__row:nth-child(3)').within(() => {

--- a/cypress/integration/operatives/summary-page.spec.js
+++ b/cypress/integration/operatives/summary-page.spec.js
@@ -73,7 +73,7 @@ describe('Summary page', () => {
             cy.get(':nth-child(1)').contains('Trade')
             cy.get(':nth-child(2)').contains('Electrician (EL)')
             cy.get(':nth-child(3)').contains('Scheme')
-            cy.get(':nth-child(4)').contains('SMV')
+            cy.get(':nth-child(4)').contains('Reactive')
           })
 
           cy.get('.govuk-summary-list__row:nth-child(3)').within(() => {

--- a/src/components/OperativeSummary/index.js
+++ b/src/components/OperativeSummary/index.js
@@ -21,7 +21,9 @@ const OperativeSummary = () => {
             {operative.tradeDescription}
           </dd>
           <dt className="govuk-summary-list__key">Scheme</dt>
-          <dd className="govuk-summary-list__value">{operative.schemeType}</dd>
+          <dd className="govuk-summary-list__value">
+            {operative.schemeDescription}
+          </dd>
         </div>
         <div className="govuk-summary-list__row">
           <dt className="govuk-summary-list__key">Salary Band</dt>

--- a/src/models/Operative.js
+++ b/src/models/Operative.js
@@ -24,6 +24,10 @@ export default class Operative {
     return this.scheme?.type
   }
 
+  get schemeDescription() {
+    return this.scheme?.description
+  }
+
   get isUnitScheme() {
     return this.scheme?.isUnitScheme
   }


### PR DESCRIPTION
There are only two schemes now (planned and reactive) and they are both SMV based so show the description instead to differentiate them.
