### PR TITLE
Use explicit non-productive flag for non-product types

### DIFF
--- a/cypress/fixtures/pay/types.json
+++ b/cypress/fixtures/pay/types.json
@@ -4,6 +4,7 @@
     "description": "Dayworks",
     "payAtBand": true,
     "paid": true,
+    "nonProductive": true,
     "productive": false,
     "adjustment": false
   },
@@ -12,6 +13,7 @@
     "description": "Annual Leave",
     "payAtBand": true,
     "paid": true,
+    "nonProductive": true,
     "productive": false,
     "adjustment": false
   },
@@ -20,6 +22,7 @@
     "description": "Public Holiday",
     "payAtBand": true,
     "paid": true,
+    "nonProductive": true,
     "productive": false,
     "adjustment": false
   },
@@ -28,6 +31,7 @@
     "description": "Sick",
     "payAtBand": true,
     "paid": true,
+    "nonProductive": true,
     "productive": false,
     "adjustment": false
   }

--- a/cypress/fixtures/timesheets/2021-10-18.json
+++ b/cypress/fixtures/timesheets/2021-10-18.json
@@ -21,6 +21,7 @@
         "description": "Dayworks",
         "payAtBand": false,
         "paid": true,
+        "nonProductive": true,
         "productive": false,
         "adjustment": false
       },
@@ -44,6 +45,7 @@
         "description": "Reactive Repairs",
         "payAtBand": true,
         "paid": true,
+        "nonProductive": false,
         "productive": true,
         "adjustment": false
       },
@@ -67,6 +69,7 @@
         "description": "Adjustment",
         "payAtBand": false,
         "paid": false,
+        "nonProductive": false,
         "productive": false,
         "adjustment": true
       },
@@ -90,6 +93,7 @@
         "description": "Annual Leave",
         "payAtBand": true,
         "paid": true,
+        "nonProductive": true,
         "productive": false,
         "adjustment": false
       },
@@ -113,6 +117,7 @@
         "description": "Reactive Repairs",
         "payAtBand": true,
         "paid": true,
+        "nonProductive": false,
         "productive": true,
         "adjustment": false
       },

--- a/src/models/PayElement.js
+++ b/src/models/PayElement.js
@@ -33,7 +33,7 @@ export default class PayElement {
   }
 
   get isNonProductive() {
-    return !(this.isAdjustment || this.isProductive)
+    return this.payElementType.nonProductive
   }
 
   get description() {

--- a/src/models/PayElementType.js
+++ b/src/models/PayElementType.js
@@ -6,11 +6,8 @@ export default class PayElementType {
     this.description = attrs.description
     this.paid = attrs.paid
     this.payAtBand = attrs.payAtBand
+    this.nonProductive = attrs.nonProductive
     this.adjustment = attrs.adjustment
     this.productive = attrs.productive
-  }
-
-  get nonProductive() {
-    return !this.adjustment && !this.productive
   }
 }


### PR DESCRIPTION
We're likely to add additional pay element types for overtime and out-of-hours so rather than rely on the implicit nature of not being the other types add an explicit flag for non-productive types so that we don't need to change the code every time we add a new flag.

Depends on LBHackney-IT/bonuscalc-api#41 being be merged and deployed.
