### PR TITLE
Use flexbox to improve column alignment in summary

### DIFF
--- a/cypress/fixtures/summaries/2021-08-02.json
+++ b/cypress/fixtures/summaries/2021-08-02.json
@@ -12,131 +12,130 @@
       "number": 1,
       "startAt": "2021-08-01T23:00:00Z",
       "closedAt": null,
-      "productiveValue": 2620.20,
+      "productiveValue": 2620.2,
       "nonProductiveDuration": 14.25,
-      "nonProductiveValue": 1453.80,
-      "totalValue": 4074.00,
-      "projectedValue": 4074.00
+      "nonProductiveValue": 1453.8,
+      "totalValue": 4074.0,
+      "projectedValue": 4074.0
     },
     {
       "number": 2,
       "startAt": "2021-08-08T23:00:00Z",
       "closedAt": null,
-      "productiveValue": 0.00,
+      "productiveValue": 0.0,
       "nonProductiveDuration": 7.25,
-      "nonProductiveValue": 739.80,
-      "totalValue": 739.80,
-      "projectedValue": 2406.90
+      "nonProductiveValue": 739.8,
+      "totalValue": 739.8,
+      "projectedValue": 2406.9
     },
     {
       "number": 3,
       "startAt": "2021-08-15T23:00:00Z",
       "closedAt": null,
-      "productiveValue": 1960.20,
+      "productiveValue": 1960.2,
       "nonProductiveDuration": 7.25,
-      "nonProductiveValue": 739.80,
-      "totalValue": 2700.00,
-      "projectedValue": 2504.60
+      "nonProductiveValue": 739.8,
+      "totalValue": 2700.0,
+      "projectedValue": 2504.6
     },
     {
       "number": 4,
       "startAt": "2021-08-22T23:00:00Z",
       "closedAt": null,
-      "productiveValue": 0.00,
+      "productiveValue": 0.0,
       "nonProductiveDuration": 7.25,
-      "nonProductiveValue": 739.80,
-      "totalValue": 739.80,
-      "projectedValue": 2063.40
+      "nonProductiveValue": 739.8,
+      "totalValue": 739.8,
+      "projectedValue": 2063.4
     },
     {
       "number": 5,
       "startAt": "2021-08-29T23:00:00Z",
       "closedAt": null,
-      "productiveValue": 3289.80,
+      "productiveValue": 3289.8,
       "nonProductiveDuration": 7.25,
-      "nonProductiveValue": 739.80,
-      "totalValue": 4029.60,
+      "nonProductiveValue": 739.8,
+      "totalValue": 4029.6,
       "projectedValue": 2456.64
     },
     {
       "number": 6,
       "startAt": "2021-09-05T23:00:00Z",
       "closedAt": null,
-      "productiveValue": 6840.00,
+      "productiveValue": 6840.0,
       "nonProductiveDuration": 7.25,
-      "nonProductiveValue": 739.80,
-      "totalValue": 7579.80,
-      "projectedValue": 3310.50
+      "nonProductiveValue": 739.8,
+      "totalValue": 7579.8,
+      "projectedValue": 3310.5
     },
     {
       "number": 7,
       "startAt": "2021-09-12T23:00:00Z",
       "closedAt": null,
-      "productiveValue": 397.20,
+      "productiveValue": 397.2,
       "nonProductiveDuration": 7.25,
-      "nonProductiveValue": 739.80,
-      "totalValue": 1137.00,
-      "projectedValue": 3000.00
-
+      "nonProductiveValue": 739.8,
+      "totalValue": 1137.0,
+      "projectedValue": 3000.0
     },
     {
       "number": 8,
       "startAt": "2021-09-19T23:00:00Z",
       "closedAt": null,
-      "productiveValue": 3265.80,
+      "productiveValue": 3265.8,
       "nonProductiveDuration": 7.25,
-      "nonProductiveValue": 739.80,
-      "totalValue": 4005.60,
-      "projectedValue": 3125.70
+      "nonProductiveValue": 739.8,
+      "totalValue": 4005.6,
+      "projectedValue": 3125.7
     },
     {
       "number": 9,
       "startAt": "2021-09-26T23:00:00Z",
       "closedAt": null,
-      "productiveValue": 0.00,
+      "productiveValue": 0.0,
       "nonProductiveDuration": 7.25,
-      "nonProductiveValue": 739.80,
-      "totalValue": 739.80,
-      "projectedValue": 2860.60
+      "nonProductiveValue": 739.8,
+      "totalValue": 739.8,
+      "projectedValue": 2860.6
     },
     {
       "number": 10,
       "startAt": "2021-10-03T23:00:00Z",
       "closedAt": null,
-      "productiveValue": 0.00,
+      "productiveValue": 0.0,
       "nonProductiveDuration": 7.25,
-      "nonProductiveValue": 739.80,
-      "totalValue": 739.80,
+      "nonProductiveValue": 739.8,
+      "totalValue": 739.8,
       "projectedValue": 2648.52
     },
     {
       "number": 11,
       "startAt": "2021-10-10T23:00:00Z",
       "closedAt": null,
-      "productiveValue": 0.00,
-      "nonProductiveDuration": 14.50,
-      "nonProductiveValue": 1479.00,
-      "totalValue": 1479.00,
-      "projectedValue": 2542.20
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 14.5,
+      "nonProductiveValue": 1479.0,
+      "totalValue": 1479.0,
+      "projectedValue": 2542.2
     },
     {
       "number": 12,
       "startAt": "2021-10-17T23:00:00Z",
       "closedAt": null,
-      "productiveValue": 0.00,
-      "nonProductiveDuration": 36.00,
-      "nonProductiveValue": 3672.00,
-      "totalValue": 3672.00,
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 36.0,
+      "nonProductiveValue": 3672.0,
+      "totalValue": 3672.0,
       "projectedValue": 2636.35
     },
     {
       "number": 13,
       "startAt": "2021-10-24T23:00:00Z",
       "closedAt": null,
-      "productiveValue": 5626.20,
+      "productiveValue": 5626.2,
       "nonProductiveDuration": 28.75,
-      "nonProductiveValue": 2832.60,
-      "totalValue": 8458.80,
+      "nonProductiveValue": 2832.6,
+      "totalValue": 8458.8,
       "projectedValue": 3084.23
     }
   ]

--- a/cypress/integration/operatives/summary-page.spec.js
+++ b/cypress/integration/operatives/summary-page.spec.js
@@ -143,9 +143,7 @@ describe('Summary page', () => {
         cy.wait('@get_summary')
 
         cy.location().should((loc) => {
-          expect(loc.pathname).to.eq(
-            '/operatives/123456/summaries/2021-11-01'
-          )
+          expect(loc.pathname).to.eq('/operatives/123456/summaries/2021-11-01')
         })
 
         cy.get('.govuk-tabs__panel').within(() => {
@@ -181,43 +179,36 @@ describe('Summary page', () => {
             cy.get(':nth-child(3)').contains('Hours (NP)')
             cy.get(':nth-child(4)').contains('SMVh (NP)')
             cy.get(':nth-child(5)').contains('Total SMVh')
-            cy.get(':nth-child(6)').contains('Band')
-            cy.get(':nth-child(7)').contains('Projected')
+            cy.get(':nth-child(6)').contains('Band Projected')
           })
         })
 
         cy.get('#weekly-summary tbody').within(() => {
           cy.get('.govuk-table__row:nth-child(1)').within(() => {
-            cy.get(':nth-child(1)').contains('1')
-            cy.get(':nth-child(2)').contains('02/08/2021')
-            cy.get(':nth-child(3)').contains('43.67')
-            cy.get(':nth-child(4)').contains('14.25')
-            cy.get(':nth-child(5)').contains('24.23')
-            cy.get(':nth-child(6)').contains('67.90')
-            cy.get(':nth-child(7)').contains('7')
-            cy.get(':nth-child(8)').contains('7')
+            cy.get(':nth-child(1)').contains('1 02/08/2021')
+            cy.get(':nth-child(2)').contains('43.67')
+            cy.get(':nth-child(3)').contains('14.25')
+            cy.get(':nth-child(4)').contains('24.23')
+            cy.get(':nth-child(5)').contains('67.90')
+            cy.get(':nth-child(6)').contains('7 7')
           })
 
           cy.get('.govuk-table__row:nth-child(6)').within(() => {
-            cy.get(':nth-child(1)').contains('6')
-            cy.get(':nth-child(2)').contains('06/09/2021')
-            cy.get(':nth-child(3)').contains('114.00')
-            cy.get(':nth-child(4)').contains('7.25')
-            cy.get(':nth-child(5)').contains('12.33')
-            cy.get(':nth-child(6)').contains('126.33')
-            cy.get(':nth-child(7)').contains('9')
-            cy.get(':nth-child(8)').contains('3')
+            cy.get(':nth-child(1)').contains('6 06/09/2021')
+            cy.get(':nth-child(2)').contains('114.00')
+            cy.get(':nth-child(3)').contains('7.25')
+            cy.get(':nth-child(4)').contains('12.33')
+            cy.get(':nth-child(5)').contains('126.33')
+            cy.get(':nth-child(6)').contains('9 3')
           })
 
           cy.get('.govuk-table__row:nth-child(13)').within(() => {
-            cy.get(':nth-child(1)').contains('13')
-            cy.get(':nth-child(2)').contains('25/10/2021')
-            cy.get(':nth-child(3)').contains('93.77')
-            cy.get(':nth-child(4)').contains('28.75')
-            cy.get(':nth-child(5)').contains('47.21')
-            cy.get(':nth-child(6)').contains('140.98')
-            cy.get(':nth-child(7)').contains('9')
-            cy.get(':nth-child(8)').contains('2')
+            cy.get(':nth-child(1)').contains('13 25/10/2021')
+            cy.get(':nth-child(2)').contains('93.77')
+            cy.get(':nth-child(3)').contains('28.75')
+            cy.get(':nth-child(4)').contains('47.21')
+            cy.get(':nth-child(5)').contains('140.98')
+            cy.get(':nth-child(6)').contains('9 2')
           })
         })
 
@@ -228,8 +219,7 @@ describe('Summary page', () => {
             cy.get(':nth-child(3)').contains('158.75')
             cy.get(':nth-child(4)').contains('268.26')
             cy.get(':nth-child(5)').contains('668.25')
-            cy.get(':nth-child(6)').contains('5')
-            cy.get(':nth-child(7)').contains('2')
+            cy.get(':nth-child(6)').contains('5→2')
           })
         })
       })

--- a/src/components/BonusPeriodSummary/WeeklySummaries.js
+++ b/src/components/BonusPeriodSummary/WeeklySummaries.js
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import PageContext from '@/components/PageContext'
 import { Table, THead, TBody, TFoot, TR, TH, TD } from '@/components/Table'
 import { numberWithPrecision } from '@/utils/number'
@@ -6,7 +7,7 @@ import { useContext } from 'react'
 
 const WeeklySummaries = () => {
   const {
-    operative: { scheme, isUnitScheme, salaryBand },
+    operative: { id, scheme, isUnitScheme, salaryBand },
     summary: {
       hasWeeklySummaries,
       weeklySummaries,
@@ -18,30 +19,33 @@ const WeeklySummaries = () => {
     },
   } = useContext(PageContext)
 
+  const baseUrl = `/operatives/${id}/timesheets`
+
   return (
-    <Table id="weekly-summary">
+    <Table id="weekly-summary" className="govuk-!-margin-top-3">
       <THead>
         <TR>
-          <TH scope="col" colSpan="2" align="centre">
+          <TH scope="col" align="centre">
             Week
           </TH>
-          <TH scope="col" align="centre">
+          <TH scope="col" numeric={true}>
             {isUnitScheme ? 'Units\u00A0(P)' : 'SMVh\u00A0(P)'}
           </TH>
-          <TH scope="col" align="centre">
+          <TH scope="col" numeric={true}>
             {'Hours\u00A0(NP)'}
           </TH>
-          <TH scope="col" align="centre">
+          <TH scope="col" numeric={true}>
             {isUnitScheme ? 'Units\u00A0(NP)' : 'SMVh\u00A0(NP)'}
           </TH>
-          <TH scope="col" align="centre">
+          <TH scope="col" numeric={true}>
             {isUnitScheme ? 'Total\u00A0Units' : 'Total\u00A0SMVh'}
           </TH>
-          <TH scope="col" align="centre" width="one-tenth">
-            Band
-          </TH>
-          <TH scope="col" align="centre">
-            Projected
+          <TH scope="col" align="centre" width="two-tenths">
+            <div className="bc-summary-payband">
+              <span>Band</span>
+              <span> </span>
+              <span>Projected</span>
+            </div>
           </TH>
         </TR>
       </THead>
@@ -50,22 +54,39 @@ const WeeklySummaries = () => {
           <TBody>
             {weeklySummaries.map((ws, index) => (
               <TR key={index}>
-                <TD numeric={true}>{ws.number}</TD>
-                <TD align="right">{ws.description}</TD>
-                <TD numeric={true}>
-                  {numberWithPrecision(
-                    smvhOrUnits(scheme, ws.productiveValue),
-                    scheme.precision
-                  )}
+                <TD align="centre">
+                  <div className="bc-summary-week">
+                    <span>{ws.number}</span>
+                    <span> </span>
+                    <span>{ws.description}</span>
+                  </div>
                 </TD>
                 <TD numeric={true}>
-                  {numberWithPrecision(ws.nonProductiveDuration, 2)}
+                  <Link href={`${baseUrl}/${ws.weekId}/productive`}>
+                    <a className="lbh-link lbh-link--no-visited-state">
+                      {numberWithPrecision(
+                        smvhOrUnits(scheme, ws.productiveValue),
+                        scheme.precision
+                      )}
+                    </a>
+                  </Link>
                 </TD>
                 <TD numeric={true}>
-                  {numberWithPrecision(
-                    smvhOrUnits(scheme, ws.nonProductiveValue),
-                    scheme.precision
-                  )}
+                  <Link href={`${baseUrl}/${ws.weekId}/non-productive`}>
+                    <a className="lbh-link lbh-link--no-visited-state">
+                      {numberWithPrecision(ws.nonProductiveDuration, 2)}
+                    </a>
+                  </Link>
+                </TD>
+                <TD numeric={true}>
+                  <Link href={`${baseUrl}/${ws.weekId}/non-productive`}>
+                    <a className="lbh-link lbh-link--no-visited-state">
+                      {numberWithPrecision(
+                        smvhOrUnits(scheme, ws.nonProductiveValue),
+                        scheme.precision
+                      )}
+                    </a>
+                  </Link>
                 </TD>
                 <TD numeric={true}>
                   {numberWithPrecision(
@@ -74,17 +95,20 @@ const WeeklySummaries = () => {
                   )}
                 </TD>
                 <TD align="centre">
-                  {bandForValue(scheme.payBands, ws.totalValue)}
-                </TD>
-                <TD align="centre">
-                  {bandForValue(scheme.payBands, ws.projectedValue)}
+                  <div className="bc-summary-payband">
+                    <span>{bandForValue(scheme.payBands, ws.totalValue)}</span>
+                    <span> </span>
+                    <span>
+                      {bandForValue(scheme.payBands, ws.projectedValue)}
+                    </span>
+                  </div>
                 </TD>
               </TR>
             ))}
           </TBody>
           <TFoot>
             <TR>
-              <TH scope="row" colSpan="2" align="right">
+              <TH scope="row" align="right">
                 Totals
               </TH>
               <TD numeric={true}>
@@ -108,9 +132,12 @@ const WeeklySummaries = () => {
                   scheme.precision
                 )}
               </TD>
-              <TD align="centre">{salaryBand}</TD>
               <TD align="centre">
-                {bandForValue(scheme.payBands, projectedValue)}
+                <div className="bc-summary-payband">
+                  <span>{salaryBand}</span>
+                  <span>&rarr;</span>
+                  <span>{bandForValue(scheme.payBands, projectedValue)}</span>
+                </div>
               </TD>
             </TR>
           </TFoot>
@@ -118,7 +145,7 @@ const WeeklySummaries = () => {
       ) : (
         <TBody>
           <TR>
-            <TD colSpan="8">There are no weekly summaries for this period.</TD>
+            <TD colSpan="6">There are no weekly summaries for this period.</TD>
           </TR>
         </TBody>
       )}

--- a/src/models/WeeklySummary.js
+++ b/src/models/WeeklySummary.js
@@ -12,6 +12,10 @@ export default class WeeklySummary {
     this.projectedValue = attrs.projectedValue
   }
 
+  get weekId() {
+    return this.startAt.toISODate()
+  }
+
   get description() {
     return this.startAt.format('DD/MM/YYYY')
   }

--- a/src/styles/all.scss
+++ b/src/styles/all.scss
@@ -1,5 +1,6 @@
 @import 'lbh-frontend/lbh/all';
 @import 'environments';
+@import 'bonus-summary';
 @import 'pay-elements';
 
 /* Bug fixes - remove when fixed in lbh-frontend */
@@ -40,6 +41,8 @@
   }
 }
 
+/* Custom widths */
+
 .govuk-\!-width-four-tenths {
   width: 40% !important;
 }
@@ -54,6 +57,25 @@
 
 .govuk-\!-width-one-tenth {
   width: 10% !important;
+}
+
+/* Table customisations */
+
+.govuk-table-s {
+  td,
+  th {
+    @include lbh-body-s;
+  }
+}
+
+.govuk-table {
+  a {
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
 }
 
 .govuk-table__foot {

--- a/src/styles/bonus-summary.scss
+++ b/src/styles/bonus-summary.scss
@@ -1,0 +1,42 @@
+.bc-summary-week {
+  display: flex;
+  justify-content: center;
+
+  span {
+    margin: 0;
+  }
+
+  span:first-child {
+    text-align: right;
+    width: 25px;
+  }
+
+  span:nth-child(2) {
+    width: 15px;
+  }
+}
+
+.bc-summary-payband {
+  display: flex;
+  justify-content: center;
+
+  span {
+    margin: 0;
+    width: 100px;
+  }
+
+  span:nth-child(2) {
+    width: 30px;
+    margin: 0 -15px;
+  }
+}
+
+.govuk-table {
+  tfoot {
+    .bc-summary-payband {
+      span:nth-child(2) {
+        @include lbh-rem(font-size, 24);
+      }
+    }
+  }
+}

--- a/src/utils/scheme.test.js
+++ b/src/utils/scheme.test.js
@@ -38,4 +38,3 @@ describe('Scheme functions', () => {
     })
   })
 })
-


### PR DESCRIPTION
Also link the respective numbers to the relevant timesheets.

![bonus-summary](https://user-images.githubusercontent.com/6321/141136858-ba675735-5d95-4447-9c34-57b3a7535b2c.png)

