### PR TITLE
Pass the pay element id back to the update request

### DIFF
--- a/src/components/EditNonProductive/AddPayElementButton.js
+++ b/src/components/EditNonProductive/AddPayElementButton.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 
 const AddPayElementButton = ({ append }) => {
   const defaults = {
+    id: null,
     payElementTypeId: null,
     workOrder: null,
     address: null,

--- a/src/components/EditNonProductive/Form.js
+++ b/src/components/EditNonProductive/Form.js
@@ -28,6 +28,7 @@ const Form = () => {
   const { fields, append, remove } = useFieldArray({
     control,
     name: 'payElements',
+    keyName: 'key',
   })
 
   const onSubmit = async (data) => {
@@ -47,6 +48,7 @@ const Form = () => {
 
   const convertPayElement = (pe) => {
     return {
+      id: pe.id,
       payElementTypeId: pe.payElementTypeId,
       workOrder: pe.workOrder,
       address: pe.address,

--- a/src/components/EditNonProductive/PayElements/Body.js
+++ b/src/components/EditNonProductive/PayElements/Body.js
@@ -10,7 +10,7 @@ const PayElementsBody = ({ fields, remove }) => {
         <>
           {fields.map((item, index) => (
             <PayElementsRow
-              key={item.id}
+              key={item.key}
               item={item}
               index={index}
               remove={remove}

--- a/src/components/EditNonProductive/PayElements/IdField.js
+++ b/src/components/EditNonProductive/PayElements/IdField.js
@@ -1,0 +1,14 @@
+import PropTypes from 'prop-types'
+import { useFormContext } from 'react-hook-form'
+
+const IdField = ({ index }) => {
+  const { register } = useFormContext()
+
+  return <input type="hidden" {...register(`payElements.${index}.id`)} />
+}
+
+IdField.propTypes = {
+  index: PropTypes.number.isRequired,
+}
+
+export default IdField

--- a/src/components/EditNonProductive/PayElements/Row.js
+++ b/src/components/EditNonProductive/PayElements/Row.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import IdField from './IdField'
 import TypeField from './TypeField'
 import DayField from './DayField'
 import NoteField from './NoteField'
@@ -14,6 +15,7 @@ const PayElementsRow = ({ item, index, remove }) => {
     <TBody className="bc-pay-element-row">
       <TR>
         <TD colSpan="2">
+          <IdField index={index} />
           <TypeField index={index} />
         </TD>
         <TD numeric={true}>


### PR DESCRIPTION
This allows the API to update the row instead of deleting and inserting a new one, thus preventing id churn in the table.
