### PR TITLE
Show past weeks instead of closed weeks

### DIFF
--- a/src/models/Summary.js
+++ b/src/models/Summary.js
@@ -50,46 +50,46 @@ export default class Summary {
     }, 1)
   }
 
-  get closedWeeklySummaries() {
-    return this.weeklySummaries.filter((ws) => ws.isClosed)
+  get pastWeeklySummaries() {
+    return this.weeklySummaries.filter((ws) => ws.isPast)
   }
 
-  get hasClosedWeeklySummaries() {
-    return this.closedWeeklySummaries.length > 0
+  get hasPastWeeklySummaries() {
+    return this.pastWeeklySummaries.length > 0
   }
 
-  get totalClosedProductiveValue() {
-    return this.closedWeeklySummaries.reduce((sum, ws) => {
+  get totalPastProductiveValue() {
+    return this.pastWeeklySummaries.reduce((sum, ws) => {
       return sum + ws.productiveValue
     }, 0)
   }
 
-  get totalClosedNonProductiveValue() {
-    return this.closedWeeklySummaries.reduce((sum, ws) => {
+  get totalPastNonProductiveValue() {
+    return this.pastWeeklySummaries.reduce((sum, ws) => {
       return sum + ws.nonProductiveValue
     }, 0)
   }
 
-  get totalClosedNonProductiveDuration() {
-    return this.closedWeeklySummaries.reduce((sum, ws) => {
+  get totalPastNonProductiveDuration() {
+    return this.pastWeeklySummaries.reduce((sum, ws) => {
       return sum + ws.nonProductiveDuration
     }, 0)
   }
 
-  get totalClosedValueForBonusPeriod() {
-    return this.closedWeeklySummaries.reduce((sum, ws) => {
+  get totalPastValueForBonusPeriod() {
+    return this.pastWeeklySummaries.reduce((sum, ws) => {
       return sum + ws.totalValue
     }, 0)
   }
 
-  get projectedClosedValue() {
-    return this.closedWeeklySummaries.reduce((projected, ws) => {
+  get projectedPastValue() {
+    return this.pastWeeklySummaries.reduce((projected, ws) => {
       return ws.projectedValue
     }, 0)
   }
 
-  get averageClosedUtilisation() {
-    return this.closedWeeklySummaries.reduce((average, ws) => {
+  get averagePastUtilisation() {
+    return this.pastWeeklySummaries.reduce((average, ws) => {
       return ws.averageUtilisation
     }, 1)
   }

--- a/src/models/WeeklySummary.js
+++ b/src/models/WeeklySummary.js
@@ -22,7 +22,23 @@ export default class WeeklySummary {
     return this.startAt.format('DD/MM/YYYY')
   }
 
+  get endAt() {
+    return this.startAt.add(1, 'week').subtract(1, 'millisecond')
+  }
+
   get isClosed() {
     return this.closedAt ? true : false
+  }
+
+  get isPast() {
+    return dayjs().isAfter(this.endAt)
+  }
+
+  get isFuture() {
+    return dayjs().isBefore(this.startAt)
+  }
+
+  get isCurrent() {
+    return !(this.isPast || this.isFuture)
   }
 }

--- a/src/utils/reports.js
+++ b/src/utils/reports.js
@@ -631,13 +631,13 @@ const drawBonusSummary = (pdf, operative, summary) => {
 
   const {
     bonusPeriod,
-    closedWeeklySummaries,
-    totalClosedNonProductiveValue,
-    totalClosedNonProductiveDuration,
-    totalClosedProductiveValue,
-    totalClosedValueForBonusPeriod,
-    projectedClosedValue,
-    averageClosedUtilisation,
+    pastWeeklySummaries,
+    totalPastNonProductiveValue,
+    totalPastNonProductiveDuration,
+    totalPastProductiveValue,
+    totalPastValueForBonusPeriod,
+    projectedPastValue,
+    averagePastUtilisation,
   } = summary
 
   const { scheme } = operative
@@ -711,7 +711,7 @@ const drawBonusSummary = (pdf, operative, summary) => {
 
   let row = 0
 
-  closedWeeklySummaries.forEach((weeklySummary) => {
+  pastWeeklySummaries.forEach((weeklySummary) => {
     row = row + 1
 
     x = originX + 7.9
@@ -793,27 +793,27 @@ const drawBonusSummary = (pdf, operative, summary) => {
   x = originX + 55.9
   y = originY + 15.5 + lineHeight * row
 
-  value = smvhOrUnits(scheme, totalClosedProductiveValue)
+  value = smvhOrUnits(scheme, totalPastProductiveValue)
   text = numberWithPrecision(value, 2)
   pdf.text(text, x, y, { align: 'right' })
 
   x = originX + 78.8
   y = originY + 15.5 + lineHeight * row
 
-  text = numberWithPrecision(totalClosedNonProductiveDuration, 2)
+  text = numberWithPrecision(totalPastNonProductiveDuration, 2)
   pdf.text(text, x, y, { align: 'right' })
 
   x = originX + 103.0
   y = originY + 15.5 + lineHeight * row
 
-  value = smvhOrUnits(scheme, totalClosedNonProductiveValue)
+  value = smvhOrUnits(scheme, totalPastNonProductiveValue)
   text = numberWithPrecision(value, 2)
   pdf.text(text, x, y, { align: 'right' })
 
   x = originX + 126.2
   y = originY + 15.5 + lineHeight * row
 
-  value = smvhOrUnits(scheme, totalClosedValueForBonusPeriod)
+  value = smvhOrUnits(scheme, totalPastValueForBonusPeriod)
   text = numberWithPrecision(value, 2)
   pdf.text(text, x, y, { align: 'right' })
 
@@ -826,11 +826,7 @@ const drawBonusSummary = (pdf, operative, summary) => {
   x = originX + 162.2
   y = originY + 15.5 + lineHeight * row
 
-  text = `${bandForValue(
-    payBands,
-    projectedClosedValue,
-    averageClosedUtilisation
-  )}`
+  text = `${bandForValue(payBands, projectedPastValue, averagePastUtilisation)}`
   pdf.text(text, x, y, { align: 'center' })
 
   x = originX + 153.4


### PR DESCRIPTION
Complaints were made about no data being in reports because weeks weren't closed so this is an option to use pasts weeks instead of closed weeks.

The downside to this is that if reports are sent out when weeks are closed then it will include data from later weeks - this may or may not be a problem as it could alert operatives to issues in their timesheets.
