### PR TITLE
Prevent editing of archived operatives

### DIFF
--- a/cypress/fixtures/operatives/archived.json
+++ b/cypress/fixtures/operatives/archived.json
@@ -1,0 +1,29 @@
+{
+  "id": "123456",
+  "name": "Alex Cable",
+  "trade": {
+    "id": "EL",
+    "description": "Electrician"
+  },
+  "section": "R3007",
+  "scheme": {
+    "type": "SMV",
+    "description": "Reactive",
+    "conversionFactor": 1.0,
+    "payBands": [
+      { "band": 1, "value": 2160 },
+      { "band": 2, "value": 2700 },
+      { "band": 3, "value": 3132 },
+      { "band": 4, "value": 3348 },
+      { "band": 5, "value": 3564 },
+      { "band": 6, "value": 3780 },
+      { "band": 7, "value": 3996 },
+      { "band": 8, "value": 4320 },
+      { "band": 9, "value": 4644 }
+    ]
+  },
+  "salaryBand": 5,
+  "utilisation": 1,
+  "fixedBand": false,
+  "isArchived": true
+}

--- a/cypress/integration/operatives/edit-non-productive-page.spec.js
+++ b/cypress/integration/operatives/edit-non-productive-page.spec.js
@@ -62,6 +62,44 @@ describe('Non-productive page', () => {
       })
     })
 
+    context('And the operative is archived', () => {
+      beforeEach(() => {
+        cy.intercept(
+          { method: 'GET', path: '/api/v1/operatives/123456' },
+          { statusCode: 200, fixture: 'operatives/archived.json' }
+        ).as('get_operative')
+
+        cy.intercept(
+          {
+            method: 'GET',
+            path: '/api/v1/operatives/123456/timesheet?week=2021-10-18',
+          },
+          { statusCode: 200, fixture: 'timesheets/2021-10-18.json' }
+        ).as('get_timesheet')
+
+        cy.intercept(
+          {
+            method: 'GET',
+            path: '/api/v1/pay/types',
+          },
+          { statusCode: 200, fixture: 'pay/types.json' }
+        ).as('get_pay_types')
+
+        cy.visit('/operatives/123456/timesheets/2021-10-18/non-productive/edit')
+        cy.wait(['@get_operative', '@get_timesheet', '@get_pay_types'])
+      })
+
+      it('Shows the access denied message', () => {
+        cy.get('.lbh-main-wrapper').contains('a', 'Back')
+        cy.get('.lbh-heading-h1').contains('Access Denied')
+        cy.get('.lbh-body').contains(
+          'Sorry, Alex Cable has been archived and is no longer editable.'
+        )
+
+        cy.audit()
+      })
+    })
+
     context('And the operative exists', () => {
       beforeEach(() => {
         cy.intercept(

--- a/cypress/integration/operatives/edit-out-of-hours-page.spec.js
+++ b/cypress/integration/operatives/edit-out-of-hours-page.spec.js
@@ -62,6 +62,44 @@ describe('Out of hours page', () => {
       })
     })
 
+    context('And the operative is archived', () => {
+      beforeEach(() => {
+        cy.intercept(
+          { method: 'GET', path: '/api/v1/operatives/123456' },
+          { statusCode: 200, fixture: 'operatives/archived.json' }
+        ).as('get_operative')
+
+        cy.intercept(
+          {
+            method: 'GET',
+            path: '/api/v1/operatives/123456/timesheet?week=2021-10-18',
+          },
+          { statusCode: 200, fixture: 'timesheets/2021-10-18.json' }
+        ).as('get_timesheet')
+
+        cy.intercept(
+          {
+            method: 'GET',
+            path: '/api/v1/pay/types',
+          },
+          { statusCode: 200, fixture: 'pay/types.json' }
+        ).as('get_pay_types')
+
+        cy.visit('/operatives/123456/timesheets/2021-10-18/out-of-hours/edit')
+        cy.wait(['@get_operative', '@get_timesheet', '@get_pay_types'])
+      })
+
+      it('Shows the access denied message', () => {
+        cy.get('.lbh-main-wrapper').contains('a', 'Back')
+        cy.get('.lbh-heading-h1').contains('Access Denied')
+        cy.get('.lbh-body').contains(
+          'Sorry, Alex Cable has been archived and is no longer editable.'
+        )
+
+        cy.audit()
+      })
+    })
+
     context('And the operative exists', () => {
       beforeEach(() => {
         cy.intercept(

--- a/cypress/integration/operatives/edit-overtime-page.spec.js
+++ b/cypress/integration/operatives/edit-overtime-page.spec.js
@@ -62,6 +62,44 @@ describe('Overtime page', () => {
       })
     })
 
+    context('And the operative is archived', () => {
+      beforeEach(() => {
+        cy.intercept(
+          { method: 'GET', path: '/api/v1/operatives/123456' },
+          { statusCode: 200, fixture: 'operatives/archived.json' }
+        ).as('get_operative')
+
+        cy.intercept(
+          {
+            method: 'GET',
+            path: '/api/v1/operatives/123456/timesheet?week=2021-10-18',
+          },
+          { statusCode: 200, fixture: 'timesheets/2021-10-18.json' }
+        ).as('get_timesheet')
+
+        cy.intercept(
+          {
+            method: 'GET',
+            path: '/api/v1/pay/types',
+          },
+          { statusCode: 200, fixture: 'pay/types.json' }
+        ).as('get_pay_types')
+
+        cy.visit('/operatives/123456/timesheets/2021-10-18/overtime/edit')
+        cy.wait(['@get_operative', '@get_timesheet', '@get_pay_types'])
+      })
+
+      it('Shows the access denied message', () => {
+        cy.get('.lbh-main-wrapper').contains('a', 'Back')
+        cy.get('.lbh-heading-h1').contains('Access Denied')
+        cy.get('.lbh-body').contains(
+          'Sorry, Alex Cable has been archived and is no longer editable.'
+        )
+
+        cy.audit()
+      })
+    })
+
     context('And the operative exists', () => {
       beforeEach(() => {
         cy.intercept(

--- a/cypress/integration/operatives/edit-productive-page.spec.js
+++ b/cypress/integration/operatives/edit-productive-page.spec.js
@@ -62,6 +62,44 @@ describe('Productive page', () => {
       })
     })
 
+    context('And the operative is archived', () => {
+      beforeEach(() => {
+        cy.intercept(
+          { method: 'GET', path: '/api/v1/operatives/123456' },
+          { statusCode: 200, fixture: 'operatives/archived.json' }
+        ).as('get_operative')
+
+        cy.intercept(
+          {
+            method: 'GET',
+            path: '/api/v1/operatives/123456/timesheet?week=2021-10-18',
+          },
+          { statusCode: 200, fixture: 'timesheets/2021-10-18.json' }
+        ).as('get_timesheet')
+
+        cy.intercept(
+          {
+            method: 'GET',
+            path: '/api/v1/pay/types',
+          },
+          { statusCode: 200, fixture: 'pay/types.json' }
+        ).as('get_pay_types')
+
+        cy.visit('/operatives/123456/timesheets/2021-10-18/productive/edit')
+        cy.wait(['@get_operative', '@get_timesheet', '@get_pay_types'])
+      })
+
+      it('Shows the access denied message', () => {
+        cy.get('.lbh-main-wrapper').contains('a', 'Back')
+        cy.get('.lbh-heading-h1').contains('Access Denied')
+        cy.get('.lbh-body').contains(
+          'Sorry, Alex Cable has been archived and is no longer editable.'
+        )
+
+        cy.audit()
+      })
+    })
+
     context('And the operative exists', () => {
       beforeEach(() => {
         cy.intercept(

--- a/cypress/integration/operatives/non-productive-page.spec.js
+++ b/cypress/integration/operatives/non-productive-page.spec.js
@@ -54,6 +54,38 @@ describe('Non-productive page', () => {
       })
     })
 
+    context('And the operative is archived', () => {
+      beforeEach(() => {
+        cy.intercept(
+          { method: 'GET', path: '/api/v1/operatives/123456' },
+          { statusCode: 200, fixture: 'operatives/archived.json' }
+        ).as('get_operative')
+
+        cy.intercept(
+          {
+            method: 'GET',
+            path: '/api/v1/operatives/123456/timesheet?week=2021-10-18',
+          },
+          { statusCode: 200, fixture: 'timesheets/2021-10-18.json' }
+        ).as('get_timesheet')
+
+        cy.visit('/operatives/123456/timesheets/2021-10-18/non-productive')
+        cy.wait(['@get_operative', '@get_timesheet'])
+      })
+
+      it('Shows the operative is archived', () => {
+        cy.get('.lbh-heading-h2').within(() => {
+          cy.contains('(Archived)')
+        })
+      })
+
+      it('Hides the edit non-productive time button', () => {
+        cy.get('.govuk-tabs__panel').within(() => {
+          cy.contains('a', 'Edit non-productive').should('not.exist')
+        })
+      })
+    })
+
     context('And the operative exists', () => {
       beforeEach(() => {
         cy.intercept(

--- a/cypress/integration/operatives/overtime-page.spec.js
+++ b/cypress/integration/operatives/overtime-page.spec.js
@@ -54,6 +54,38 @@ describe('Overtime page', () => {
       })
     })
 
+    context('And the operative is archived', () => {
+      beforeEach(() => {
+        cy.intercept(
+          { method: 'GET', path: '/api/v1/operatives/123456' },
+          { statusCode: 200, fixture: 'operatives/archived.json' }
+        ).as('get_operative')
+
+        cy.intercept(
+          {
+            method: 'GET',
+            path: '/api/v1/operatives/123456/timesheet?week=2021-10-18',
+          },
+          { statusCode: 200, fixture: 'timesheets/2021-10-18.json' }
+        ).as('get_timesheet')
+
+        cy.visit('/operatives/123456/timesheets/2021-10-18/overtime')
+        cy.wait(['@get_operative', '@get_timesheet'])
+      })
+
+      it('Shows the operative is archived', () => {
+        cy.get('.lbh-heading-h2').within(() => {
+          cy.contains('(Archived)')
+        })
+      })
+
+      it('Hides the edit out of hours time button', () => {
+        cy.get('.govuk-tabs__panel').within(() => {
+          cy.contains('a', 'Edit overtime').should('not.exist')
+        })
+      })
+    })
+
     context('And the operative exists', () => {
       beforeEach(() => {
         cy.intercept(
@@ -305,6 +337,27 @@ describe('Overtime page', () => {
             cy.get(':nth-child(1)').contains('Total')
             cy.get(':nth-child(2)').contains('£86.40')
           })
+        })
+      })
+
+      it('Hides the edit overtime button if the week is closed', () => {
+        cy.intercept(
+          {
+            method: 'GET',
+            path: '/api/v1/operatives/123456/timesheet?week=2021-10-11',
+          },
+          { statusCode: 200, fixture: 'timesheets/2021-10-11.json' }
+        ).as('get_timesheet')
+
+        cy.get('.govuk-tabs__panel').within(() => {
+          cy.contains('a', 'Edit overtime').should('exist')
+
+          cy.get('.lbh-simple-pagination')
+            .contains('a', 'Period 3 – 2021 / week 11')
+            .click()
+          cy.wait('@get_timesheet')
+
+          cy.contains('a', 'Edit overtime').should('not.exist')
         })
       })
     })

--- a/cypress/integration/operatives/productive-page.spec.js
+++ b/cypress/integration/operatives/productive-page.spec.js
@@ -54,6 +54,38 @@ describe('Productive page', () => {
       })
     })
 
+    context('And the operative is archived', () => {
+      beforeEach(() => {
+        cy.intercept(
+          { method: 'GET', path: '/api/v1/operatives/123456' },
+          { statusCode: 200, fixture: 'operatives/archived.json' }
+        ).as('get_operative')
+
+        cy.intercept(
+          {
+            method: 'GET',
+            path: '/api/v1/operatives/123456/timesheet?week=2021-10-18',
+          },
+          { statusCode: 200, fixture: 'timesheets/2021-10-18.json' }
+        ).as('get_timesheet')
+
+        cy.visit('/operatives/123456/timesheets/2021-10-18/productive')
+        cy.wait(['@get_operative', '@get_timesheet'])
+      })
+
+      it('Shows the operative is archived', () => {
+        cy.get('.lbh-heading-h2').within(() => {
+          cy.contains('(Archived)')
+        })
+      })
+
+      it('Hides the edit out of hours time button', () => {
+        cy.get('.govuk-tabs__panel').within(() => {
+          cy.contains('a', 'Edit overtime').should('not.exist')
+        })
+      })
+    })
+
     context('And the operative exists', () => {
       beforeEach(() => {
         cy.intercept(
@@ -264,6 +296,27 @@ describe('Productive page', () => {
             cy.get(':nth-child(1)').contains('Total')
             cy.get(':nth-child(2)').contains('1.50')
           })
+        })
+      })
+
+      it('Hides the edit productive time button if the week is closed', () => {
+        cy.intercept(
+          {
+            method: 'GET',
+            path: '/api/v1/operatives/123456/timesheet?week=2021-10-11',
+          },
+          { statusCode: 200, fixture: 'timesheets/2021-10-11.json' }
+        ).as('get_timesheet')
+
+        cy.get('.govuk-tabs__panel').within(() => {
+          cy.contains('a', 'Edit productive').should('exist')
+
+          cy.get('.lbh-simple-pagination')
+            .contains('a', 'Period 3 – 2021 / week 11')
+            .click()
+          cy.wait('@get_timesheet')
+
+          cy.contains('a', 'Edit productive').should('not.exist')
         })
       })
 

--- a/cypress/integration/operatives/summary-page.spec.js
+++ b/cypress/integration/operatives/summary-page.spec.js
@@ -54,6 +54,32 @@ describe('Summary page', () => {
       })
     })
 
+    context('And the operative is archived', () => {
+      beforeEach(() => {
+        cy.intercept(
+          { method: 'GET', path: '/api/v1/operatives/123456' },
+          { statusCode: 200, fixture: 'operatives/archived.json' }
+        ).as('get_operative')
+
+        cy.intercept(
+          {
+            method: 'GET',
+            path: '/api/v1/operatives/123456/summary?bonusPeriod=2021-08-02',
+          },
+          { statusCode: 200, fixture: 'summaries/2021-08-02.json' }
+        ).as('get_summary')
+
+        cy.visit('/operatives/123456/summaries/2021-08-02')
+        cy.wait(['@get_operative', '@get_summary'])
+      })
+
+      it('Shows the operative is archived', () => {
+        cy.get('.lbh-heading-h2').within(() => {
+          cy.contains('(Archived)')
+        })
+      })
+    })
+
     context('And the operative exists', () => {
       beforeEach(() => {
         cy.intercept(

--- a/src/components/EditOperativePage/index.js
+++ b/src/components/EditOperativePage/index.js
@@ -46,6 +46,23 @@ const EditOperativePage = ({
       </NotFound>
     )
 
+  const bonusPeriod = BonusPeriod.forWeek(week)
+  const baseUrl = `/operatives/${operative.id}`
+  const backUrl = `${baseUrl}/timesheets/${week}/${tab}`
+
+  if (operative.isArchived)
+    return (
+      <>
+        <BackButton href={backUrl} />
+        <section className="section">
+          <h1 className="lbh-heading-h1">Access Denied</h1>
+          <p className="lbh-body">
+            Sorry, {operative.name} has been archived and is no longer editable.
+          </p>
+        </section>
+      </>
+    )
+
   if (isTimesheetLoading) return <Spinner />
   if (isTimesheetError || !timesheet)
     return <NotFound>Couldn’t find a timesheet for the date {week}.</NotFound>
@@ -53,10 +70,6 @@ const EditOperativePage = ({
   if (isPayElementTypesLoading) return <Spinner />
   if (isPayElementTypesError || !allPayElementTypes)
     return <NotFound>Couldn’t fetch the list of pay element types.</NotFound>
-
-  const bonusPeriod = BonusPeriod.forWeek(week)
-  const baseUrl = `/operatives/${operative.id}`
-  const backUrl = `${baseUrl}/timesheets/${week}/${tab}`
 
   const payElements = selectPayElements(timesheet)
   const payElementTypes = selectPayElementTypes(allPayElementTypes)

--- a/src/components/NonProductiveSummary/index.js
+++ b/src/components/NonProductiveSummary/index.js
@@ -37,7 +37,7 @@ const NonProductiveSummary = () => {
       <ButtonGroup>
         <Button onClick={downloadReport}>Download report</Button>
 
-        {week.isEditable && (
+        {week.isEditable && operative.isEditable && (
           <ButtonLink href={`${baseUrl}/non-productive/edit`} secondary={true}>
             Edit non-productive
           </ButtonLink>

--- a/src/components/OperativeSummary/index.js
+++ b/src/components/OperativeSummary/index.js
@@ -6,7 +6,14 @@ const OperativeSummary = () => {
 
   return (
     <section className="section">
-      <h1 className="lbh-heading-h2">{operative.name}</h1>
+      <h1 className="lbh-heading-h2">
+        {operative.name}
+        {operative.isArchived && (
+          <span className="govuk-caption-m lbh-caption govuk-!-display-inline-block govuk-!-margin-left-3">
+            (Archived)
+          </span>
+        )}
+      </h1>
 
       <dl className="govuk-summary-list lbh-summary-list govuk-!-margin-top-5">
         <div className="govuk-summary-list__row">

--- a/src/components/OutOfHoursSummary/index.js
+++ b/src/components/OutOfHoursSummary/index.js
@@ -27,7 +27,7 @@ const OutOfHoursSummary = () => {
       <ButtonGroup>
         <Button onClick={downloadReport}>Download report</Button>
 
-        {week.isEditable && (
+        {week.isEditable && operative.isEditable && (
           <ButtonLink href={`${baseUrl}/out-of-hours/edit`} secondary={true}>
             Edit out of hours
           </ButtonLink>

--- a/src/components/OvertimeSummary/index.js
+++ b/src/components/OvertimeSummary/index.js
@@ -27,7 +27,7 @@ const OvertimeSummary = () => {
       <ButtonGroup>
         <Button onClick={downloadReport}>Download report</Button>
 
-        {week.isEditable && (
+        {week.isEditable && operative.isEditable && (
           <ButtonLink href={`${baseUrl}/overtime/edit`} secondary={true}>
             Edit overtime
           </ButtonLink>

--- a/src/components/ProductiveSummary/index.js
+++ b/src/components/ProductiveSummary/index.js
@@ -50,7 +50,7 @@ const ProductiveSummary = () => {
       <ButtonGroup>
         <Button onClick={downloadReport}>Download report</Button>
 
-        {week.isEditable && (
+        {week.isEditable && operative.isEditable && (
           <ButtonLink href={`${baseUrl}/productive/edit`} secondary={true}>
             Edit productive
           </ButtonLink>

--- a/src/models/Operative.js
+++ b/src/models/Operative.js
@@ -11,6 +11,7 @@ export default class Operative {
     this.utilisation = attrs.utilisation
     this.fixedBand = attrs.fixedBand
     this.trade = new Trade(attrs.trade)
+    this.isArchived = attrs.isArchived
   }
 
   payBand(payAtBand) {
@@ -45,5 +46,9 @@ export default class Operative {
     return this.payBands.find(
       (pb) => pb.band == this.salaryBand || pb.band == 3
     )
+  }
+
+  get isEditable() {
+    return !this.isArchived
   }
 }


### PR DESCRIPTION
Tag the operative name with a '(Archived)' caption, disable the edit button and prevent direct access to the edit pages.
