### PR TITLE
Tell serverless-http what types are binary

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -38,6 +38,7 @@ functions:
     environment:
       BONUSCALC_SERVICE_API_URL: ${ssm:/dlo-bonus-scheme/${self:provider.stage}/service-api-url}
       BONUSCALC_SERVICE_API_KEY: ${ssm:/dlo-bonus-scheme/${self:provider.stage}/service-api-key}
+      BINARY_CONTENT_TYPES: application/pdf
       GSSO_URL: ${ssm:/dlo-bonus-scheme/${self:provider.stage}/gsso-url}
       GSSO_TOKEN_NAME: ${ssm:/dlo-bonus-scheme/${self:provider.stage}/gsso-token-name}
       HACKNEY_JWT_SECRET: ${ssm:/dlo-bonus-scheme/${self:provider.stage}/hackney-jwt-secret}


### PR DESCRIPTION
The serverless-http package needs to know what types are binary so it can return the correct response to the API Gateway.