### PR TITLE
Use wildcard for binary media types

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -11,7 +11,7 @@ provider:
   apiGateway:
     shouldStartNameWithService: true
     binaryMediaTypes:
-      - 'application/pdf'
+      - '*/*'
 
 package:
   individually: true


### PR DESCRIPTION
Even though the Lambda function is returning base64 encoded content, the API Gateway isn't converting it to binary. It seems that according to AWS forum posts that the Accept header needs to match the binary media type specified in the settings. Since the request is being sent through CloudFront it's possible that the Accept header we send isn't being forwarded so enable binary media types for the wildcard.
