### PR TITLE
Reduce Lambda package size

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -27,8 +27,17 @@ functions:
         - 'src/lambda.js'
         - 'next.config.js'
         - 'public/**'
-        - 'build/_next/**'
+        - 'build/_next/BUILD_ID'
+        - 'build/_next/*.json'
+        - 'build/_next/server/**'
+        - 'build/_next/static/**'
         - 'node_modules/**'
+        - '!node_modules/@next/swc-darwin-arm64'
+        - '!node_modules/@next/swc-darwin-x64'
+        - '!node_modules/@next/swc-linux-x64-gnu'
+        - '!node_modules/@next/swc-win32-x64-msvc'
+        - '!node_modules/@sentry/cli'
+        - '!node_modules/leaflet'
     events:
       - http: ANY /
       - http: ANY /{proxy+}


### PR DESCRIPTION
Don't include the cache directory and remove packages with large binaries.
