### PR TITLE
Restore @sentry/cli package

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -36,7 +36,7 @@ functions:
         - '!node_modules/@next/swc-darwin-x64'
         - '!node_modules/@next/swc-linux-x64-gnu'
         - '!node_modules/@next/swc-win32-x64-msvc'
-        - '!node_modules/@sentry/cli'
+        - '!node_modules/@sentry/cli/sentry-cli'
         - '!node_modules/leaflet'
     events:
       - http: ANY /


### PR DESCRIPTION
Just remove the platform-specific file instead.
