### PR TITLE
Not every event has a request

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -66,7 +66,7 @@ BonusCalcApp.getInitialProps = async ({ ctx, Component: pageComponent }) => {
 
   configureScope((scope) => {
     scope.addEventProcessor((event) => {
-      if (event.request.cookies[GSSO_TOKEN_NAME]) {
+      if (event.request?.cookies[GSSO_TOKEN_NAME]) {
         event.request.cookies[GSSO_TOKEN_NAME] = '[REMOVED]'
       }
 

--- a/src/utils/apiAuth.js
+++ b/src/utils/apiAuth.js
@@ -44,7 +44,7 @@ export const authoriseAPIRequest = (callback) => {
 
       Sentry.configureScope((scope) => {
         scope.addEventProcessor((event) => {
-          if (event.request.cookies[GSSO_TOKEN_NAME]) {
+          if (event.request?.cookies[GSSO_TOKEN_NAME]) {
             event.request.cookies[GSSO_TOKEN_NAME] = '[REMOVED]'
           }
 


### PR DESCRIPTION
Sometimes the event happens outside of a request so there's no cookie to remove.
