### PR TITLE
Add sorting to all operatives

### DIFF
--- a/src/components/AllOperativesList/index.js
+++ b/src/components/AllOperativesList/index.js
@@ -1,9 +1,11 @@
 import PropTypes from 'prop-types'
 import Link from 'next/link'
+import ButtonGroup from '@/components/ButtonGroup'
+import ButtonLink from '@/components/ButtonLink'
 import { useState, useRef } from 'react'
 import { SearchIcon, CrossIcon } from '@/components/Icons'
 import { Table, THead, TBody, TR, TH, TD } from '@/components/Table'
-import { Scheme, Week } from '@/models'
+import { BonusPeriod, Scheme, Week } from '@/models'
 import { numberWithPrecision } from '@/utils/number'
 import { smvh, bandForValue } from '@/utils/scheme'
 import { escapeRegExp, transliterate } from '@/utils/string'
@@ -174,20 +176,34 @@ const Operatives = ({ week, operatives }) => {
   )
 }
 
-const AllOperativesList = ({ week, schemes }) => {
+const AllOperativesList = ({ period, week, schemes }) => {
   week.operativeSummaries.forEach((os) => {
     os.scheme = schemes[os.schemeId]
   })
+
+  const firstOpenWeek = period.weeks.find((week) => week.isEditable)
+  const showCloseWeek = week.id == firstOpenWeek.id
+  const baseUrl = `/manage/weeks/${week.id}/close`
+  const backUrl = encodeURIComponent(`/manage/weeks/${week.id}/operatives`)
 
   return (
     <section className="bc-all-operatives">
       <Header week={week} />
       <Search week={week} />
+
+      {showCloseWeek && (
+        <ButtonGroup>
+          <ButtonLink href={`${baseUrl}?backUrl=${backUrl}`}>
+            Close week
+          </ButtonLink>
+        </ButtonGroup>
+      )}
     </section>
   )
 }
 
 AllOperativesList.propTypes = {
+  period: PropTypes.instanceOf(BonusPeriod),
   week: PropTypes.instanceOf(Week).isRequired,
   schemes: PropTypes.objectOf(PropTypes.instanceOf(Scheme)).isRequired,
 }

--- a/src/components/AllOperativesList/index.js
+++ b/src/components/AllOperativesList/index.js
@@ -1,3 +1,4 @@
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import Link from 'next/link'
 import ButtonGroup from '@/components/ButtonGroup'
@@ -7,7 +8,8 @@ import { SearchIcon, CrossIcon } from '@/components/Icons'
 import { Table, THead, TBody, TR, TH, TD } from '@/components/Table'
 import { BonusPeriod, Scheme, Week } from '@/models'
 import { numberWithPrecision } from '@/utils/number'
-import { smvh, bandForValue } from '@/utils/scheme'
+import { smvh } from '@/utils/scheme'
+import { compareStrings } from '@/utils/string'
 import { escapeRegExp, transliterate } from '@/utils/string'
 
 const Header = ({ week }) => {
@@ -78,34 +80,83 @@ const Operatives = ({ week, operatives }) => {
   const productiveUrl = `timesheets/${week}/productive?backUrl=${backUrl}`
   const nonProductiveUrl = `timesheets/${week}/non-productive?backUrl=${backUrl}`
 
+  const [sortBy, setSortBy] = useState('id')
+  const [sortOrder, setSortOrder] = useState('ASC')
+
+  const sortOn = (property) => {
+    return () => {
+      if (sortBy == property) {
+        if (sortOrder == 'ASC') {
+          setSortOrder('DESC')
+        } else {
+          setSortOrder('ASC')
+        }
+      } else {
+        setSortBy(property)
+      }
+    }
+  }
+
+  const sortClass = (property) => {
+    return cx(
+      sortBy == property ? 'bc-sort' : null,
+      sortBy == property && sortOrder == 'DESC' ? 'bc-sort-desc' : null
+    )
+  }
+
+  const buttonProps = (property) => {
+    return {
+      onClick: sortOn(property),
+      className: sortClass(property),
+    }
+  }
+
+  if (sortOrder == 'ASC') {
+    operatives.sort((a, b) => {
+      return compareStrings(a[sortBy], b[sortBy])
+    })
+  } else {
+    operatives.sort((a, b) => {
+      return compareStrings(b[sortBy], a[sortBy])
+    })
+  }
+
   return (
     <Table className="bc-all-operatives__list">
       <THead>
         <TR>
-          <TH scope="col">{'Operative\u00A0name'}</TH>
-          <TH scope="col" align="centre">
-            {'Payroll\u00A0no.'}
+          <TH scope="col">
+            <button {...buttonProps('name')}>{'Operative\u00A0name'}</button>
           </TH>
           <TH scope="col" align="centre">
-            Trade
+            <button {...buttonProps('id')}>{'Payroll\u00A0no.'}</button>
+          </TH>
+          <TH scope="col" align="centre">
+            <button {...buttonProps('tradeCode')}>Trade</button>
           </TH>
           <TH scope="col" numeric={true}>
-            {'SMVh\u00A0(P)'}
+            <button {...buttonProps('productiveValue')}>
+              {'SMVh\u00A0(P)'}
+            </button>
           </TH>
           <TH scope="col" numeric={true}>
-            {'Hours\u00A0(NP)'}
+            <button {...buttonProps('nonProductiveDuration')}>
+              {'Hours\u00A0(NP)'}
+            </button>
           </TH>
           <TH scope="col" numeric={true}>
-            {'SMVh\u00A0(NP)'}
+            <button {...buttonProps('nonProductiveValue')}>
+              {'SMVh\u00A0(NP)'}
+            </button>
           </TH>
           <TH scope="col" numeric={true}>
-            {'Total\u00A0SMVh'}
+            <button {...buttonProps('totalValue')}>{'Total\u00A0SMVh'}</button>
           </TH>
           <TH scope="col" align="centre">
             <div className="bc-summary-payband">
-              <span>Band</span>
+              <button {...buttonProps('payBand')}>Band</button>
               <span> </span>
-              <span>Projected</span>
+              <button {...buttonProps('projectedPayBand')}>Projected</button>
             </div>
           </TH>
         </TR>
@@ -147,21 +198,9 @@ const Operatives = ({ week, operatives }) => {
               </TD>
               <TD align="centre">
                 <div className="bc-summary-payband">
-                  <span>
-                    {bandForValue(
-                      o.scheme.payBands,
-                      o.totalValue,
-                      o.utilisation
-                    )}
-                  </span>
+                  <span>{o.payBand}</span>
                   <span> </span>
-                  <span>
-                    {bandForValue(
-                      o.scheme.payBands,
-                      o.projectedValue,
-                      o.averageUtilisation
-                    )}
-                  </span>
+                  <span>{o.projectedPayBand}</span>
                 </div>
               </TD>
             </TR>

--- a/src/models/OperativeSummary.js
+++ b/src/models/OperativeSummary.js
@@ -1,4 +1,5 @@
 import Trade from './Trade'
+import { bandForValue } from '@/utils/scheme'
 import { transliterate } from '@/utils/string'
 
 export default class OperativeSummary {
@@ -21,8 +22,24 @@ export default class OperativeSummary {
     return `${this.name} (${this.id})`
   }
 
+  get tradeCode() {
+    return this.trade.id
+  }
+
   get tradeDescription() {
     return `${this.trade.description} (${this.trade.id})`
+  }
+
+  get payBand() {
+    return this.payBandFor(this.totalValue, this.utilisation)
+  }
+
+  get projectedPayBand() {
+    return this.payBandFor(this.projectedValue, this.averageUtilisation)
+  }
+
+  payBandFor(value, utilisation) {
+    return bandForValue(this.scheme.payBands, value, utilisation)
   }
 
   matches(pattern) {

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -2,6 +2,7 @@ import '@/styles/all.scss'
 import App from 'next/app'
 import Layout from '@/components/Layout'
 import AccessDenied from '@/components/AccessDenied'
+import { StrictMode } from 'react'
 import { configureScope, setUser } from '@sentry/nextjs'
 
 import {
@@ -30,7 +31,7 @@ class BonusCalcApp extends App {
     }
 
     return (
-      <>
+      <StrictMode>
         <UserContext.Provider value={{ user: this.props.userDetails }}>
           <Layout
             serviceName="DLO Bonus Scheme"
@@ -43,7 +44,7 @@ class BonusCalcApp extends App {
             />
           </Layout>
         </UserContext.Provider>
-      </>
+      </StrictMode>
     )
   }
 }

--- a/src/pages/manage/weeks/[week]/close.js
+++ b/src/pages/manage/weeks/[week]/close.js
@@ -14,7 +14,7 @@ const CloseWeekPage = ({ query }) => {
 
   return (
     <>
-      <BackButton href="/manage/weeks" />
+      <BackButton href={query.backUrl || '/manage/weeks'} />
       <CloseWeek week={week} />
     </>
   )

--- a/src/pages/manage/weeks/[week]/operatives.js
+++ b/src/pages/manage/weeks/[week]/operatives.js
@@ -2,7 +2,7 @@ import BackButton from '@/components/BackButton'
 import NotFound from '@/components/NotFound'
 import Spinner from '@/components/Spinner'
 import AllOperativesList from '@/components/AllOperativesList'
-import { useSchemes, useWeek } from '@/utils/apiClient'
+import { useSchemes, useWeek, useBonusPeriods } from '@/utils/apiClient'
 import { OPERATIVE_MANAGER_ROLE, WEEK_MANAGER_ROLE } from '@/utils/user'
 
 const AllOperativesPage = ({ query }) => {
@@ -17,6 +17,12 @@ const AllOperativesPage = ({ query }) => {
     isLoading: isSchemesLoading,
     isError: isSchemesError,
   } = useSchemes()
+
+  const {
+    bonusPeriods,
+    isLoading: isBonusPeriodsLoading,
+    isError: isBonusPeriodsError,
+  } = useBonusPeriods()
 
   if (isWeekLoading) return <Spinner />
   if (isWeekError || !week)
@@ -34,10 +40,16 @@ const AllOperativesPage = ({ query }) => {
       </NotFound>
     )
 
+  if (isBonusPeriodsLoading) return <Spinner />
+  if (isBonusPeriodsError || !bonusPeriods)
+    return <NotFound>Couldn’t find any current bonus periods.</NotFound>
+
+  const period = bonusPeriods.find((p) => p.id == week.bonusPeriod.id)
+
   return (
     <>
       <BackButton href="/manage/weeks" />
-      <AllOperativesList week={week} schemes={schemes} />
+      <AllOperativesList period={period} week={week} schemes={schemes} />
     </>
   )
 }

--- a/src/styles/all-operatives.scss
+++ b/src/styles/all-operatives.scss
@@ -78,23 +78,67 @@
       }
 
       th:nth-child(1) {
-        width: 200px;
+        width: 190px;
       }
 
       th:nth-child(2) {
-        width: 95px;
+        width: 90px;
       }
 
       th:nth-child(3) {
-        width: 85px;
+        width: 80px;
       }
 
       th:nth-child(n + 4):nth-child(-n + 7) {
-        width: 95px;
+        width: 100px;
       }
 
       th:nth-child(8) {
         width: 200px;
+      }
+
+      button {
+        @include lbh-rem(font-size, 14);
+
+        appearance: none;
+        background: none;
+        border: none;
+        cursor: pointer;
+        display: inline-flex;
+        font-weight: 600;
+        padding: 0;
+
+        &::before {
+          background-image: url("data:image/svg+xml,%3Csvg width='160' height='160' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m83.536 13.536 47.928 47.928A5 5 0 0 1 127.93 70H32.07a5 5 0 0 1-3.535-8.536l47.928-47.928a5 5 0 0 1 7.072 0ZM83.536 146.464l47.928-47.928A5 5 0 0 0 127.93 90H32.07a5 5 0 0 0-3.535 8.536l47.928 47.928a5 5 0 0 0 7.072 0Z'/%3E%3C/svg%3E%0A");
+          background-size: 16px;
+          background-repeat: no-repeat;
+          background-position: center;
+          content: '';
+          width: 12px;
+          height: 16px;
+          margin-left: -12px;
+          margin-right: 4px;
+        }
+
+        &.bc-sort {
+          &::before {
+            background-image: url("data:image/svg+xml,%3Csvg width='160' height='160' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m83.536 106.464 47.928-47.928A5 5 0 0 0 127.93 50H32.07a5 5 0 0 0-3.535 8.536l47.928 47.928a5 5 0 0 0 7.072 0Z' fill-rule='evenodd'/%3E%3C/svg%3E");
+          }
+        }
+
+        &.bc-sort.bc-sort-desc {
+          &::before {
+            background-image: url("data:image/svg+xml,%3Csvg width='160' height='160' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m83.536 53.536 47.928 47.928A5 5 0 0 1 127.93 110H32.07a5 5 0 0 1-3.535-8.536l47.928-47.928a5 5 0 0 1 7.072 0Z'/%3E%3C/svg%3E");
+          }
+        }
+      }
+
+      th:nth-child(1) {
+        button {
+          &::before {
+            margin-left: 0;
+          }
+        }
       }
     }
 
@@ -117,10 +161,13 @@
   }
 
   .bc-summary-payband {
+    display: inline-flex;
     padding-left: 10px;
     padding-right: 10px;
 
-    span {
+    span,
+    button {
+      justify-content: center;
       margin: 0;
       width: 80px;
     }


### PR DESCRIPTION
### Description of change

Implements the sorting and the 'Close week' button A/Cs for the story *"As a manager, I can view all operatives in a summary view, so I can see the total SMVs"*

### Story Link

https://www.pivotaltracker.com/story/show/180442552

![image](https://user-images.githubusercontent.com/6321/150675198-831e33db-9add-4361-8b0e-5682c57cd9bb.png)
