### PR TITLE
Allow access to all operatives when period is closed

### DIFF
--- a/src/components/AllOperativesList/index.js
+++ b/src/components/AllOperativesList/index.js
@@ -221,7 +221,7 @@ const AllOperativesList = ({ period, week, schemes }) => {
   })
 
   const firstOpenWeek = period.weeks.find((week) => week.isEditable)
-  const showCloseWeek = week.id == firstOpenWeek.id
+  const showCloseWeek = week.id == firstOpenWeek?.id
   const baseUrl = `/manage/weeks/${week.id}/close`
   const backUrl = encodeURIComponent(`/manage/weeks/${week.id}/operatives`)
 


### PR DESCRIPTION
There is no first open week in a period when every week is closed.
