### PR TITLE
Display ooh/overtime jobs as money and not SMVs

### DIFF
--- a/cypress/fixtures/search/work_elements/out-of-hours.json
+++ b/cypress/fixtures/search/work_elements/out-of-hours.json
@@ -1,0 +1,39 @@
+[
+  {
+    "id": 1,
+    "payElementType": {
+      "id": 501,
+      "description": "OOH Job",
+      "payAtBand": true,
+      "paid": true,
+      "nonProductive": false,
+      "productive": false,
+      "adjustment": false,
+      "outOfHours": true,
+      "overtime": false,
+      "selectable": false
+    },
+    "workOrder": "12345678",
+    "address": "2 Somewhere Street",
+    "description": "Replace broken light switch",
+    "operativeId": "123456",
+    "operativeName": "Alex Cable",
+    "week": {
+      "id": "2021-10-18",
+      "bonusPeriod": {
+        "id": "2021-08-02",
+        "startAt": "2021-08-01T23:00:00Z",
+        "year": 2021,
+        "number": 3,
+        "closedAt": null
+      },
+      "startAt": "2021-10-17T23:00:00Z",
+      "number": 12,
+      "closedAt": null,
+      "closedBy": null,
+      "reportsSentAt": null
+    },
+    "value": 20.0,
+    "closedAt": "2021-10-19T10:30:00Z"
+  }
+]

--- a/cypress/fixtures/search/work_elements/overtime.json
+++ b/cypress/fixtures/search/work_elements/overtime.json
@@ -1,0 +1,39 @@
+[
+  {
+    "id": 1,
+    "payElementType": {
+      "id": 401,
+      "description": "Overtime Job",
+      "payAtBand": true,
+      "paid": true,
+      "nonProductive": false,
+      "productive": false,
+      "adjustment": false,
+      "outOfHours": false,
+      "overtime": true,
+      "selectable": false
+    },
+    "workOrder": "12345678",
+    "address": "2 Somewhere Street",
+    "description": "Replace broken light switch",
+    "operativeId": "123456",
+    "operativeName": "Alex Cable",
+    "week": {
+      "id": "2021-10-18",
+      "bonusPeriod": {
+        "id": "2021-08-02",
+        "startAt": "2021-08-01T23:00:00Z",
+        "year": 2021,
+        "number": 3,
+        "closedAt": null
+      },
+      "startAt": "2021-10-17T23:00:00Z",
+      "number": 12,
+      "closedAt": null,
+      "closedBy": null,
+      "reportsSentAt": null
+    },
+    "value": 21.6,
+    "closedAt": "2021-10-19T10:30:00Z"
+  }
+]

--- a/cypress/integration/search-page.spec.js
+++ b/cypress/integration/search-page.spec.js
@@ -211,7 +211,7 @@ describe('Search page', () => {
             cy.get(':nth-child(3)').contains('Work order')
             cy.get(':nth-child(4)').contains('Property')
             cy.get(':nth-child(5)').contains('Close date')
-            cy.get(':nth-child(6)').contains('SMVh')
+            cy.get(':nth-child(6)').contains('Value')
             cy.get(':nth-child(7)').contains('Period')
             cy.get(':nth-child(8)').contains('Week')
           })
@@ -253,6 +253,162 @@ describe('Search page', () => {
                 expect(link).to.have.attr(
                   'href',
                   '/operatives/123456/timesheets/2021-10-18/productive'
+                )
+              })
+          })
+        })
+
+        cy.audit()
+      })
+    })
+
+    describe('Search for an out-of-hours work order', () => {
+      beforeEach(() => {
+        cy.visit('/search')
+
+        cy.get('#formView_workOrder').click()
+        cy.get('#workOrderSearch').clear()
+      })
+
+      it('Displays a list of work orders', () => {
+        cy.intercept(
+          { method: 'GET', path: '/api/v1/work/elements?query=12345678' },
+          { statusCode: 200, fixture: 'search/work_elements/out-of-hours.json' }
+        ).as('get_work_elements')
+
+        cy.get('#workOrderSearch').type('12345678')
+        cy.get('button').click()
+
+        cy.wait('@get_work_elements')
+        cy.contains('We found 1 matching result for: 12345678')
+
+        cy.get('table').within(() => {
+          cy.get('thead > tr:nth-child(1)').within(() => {
+            cy.get(':nth-child(1)').contains('Operative name')
+            cy.get(':nth-child(2)').contains('Payroll no.')
+            cy.get(':nth-child(3)').contains('Work order')
+            cy.get(':nth-child(4)').contains('Property')
+            cy.get(':nth-child(5)').contains('Close date')
+            cy.get(':nth-child(6)').contains('Value')
+            cy.get(':nth-child(7)').contains('Period')
+            cy.get(':nth-child(8)').contains('Week')
+          })
+
+          cy.get('tbody > tr:nth-child(1)').within(() => {
+            cy.get(':nth-child(1)')
+              .contains('a', 'Alex Cable')
+              .should((link) => {
+                expect(link).to.have.attr('href', '/operatives/123456')
+              })
+            cy.get(':nth-child(2)')
+              .contains('a', '123456')
+              .should((link) => {
+                expect(link).to.have.attr('href', '/operatives/123456')
+              })
+            cy.get(':nth-child(3)')
+              .contains('a', '12345678')
+              .should((link) => {
+                expect(link).to.have.attr(
+                  'href',
+                  'https://repairs-hub.hackney.gov.uk/work-orders/12345678'
+                )
+                expect(link).to.have.attr('target', '_blank')
+              })
+            cy.get(':nth-child(4)').contains('2 Somewhere Street')
+            cy.get(':nth-child(5)').contains('19/10/2021')
+            cy.get(':nth-child(6)').contains('£20.00')
+            cy.get(':nth-child(7)')
+              .contains('a', '3')
+              .should((link) => {
+                expect(link).to.have.attr(
+                  'href',
+                  '/operatives/123456/summaries/2021-08-02'
+                )
+              })
+            cy.get(':nth-child(8)')
+              .contains('a', '12')
+              .should((link) => {
+                expect(link).to.have.attr(
+                  'href',
+                  '/operatives/123456/timesheets/2021-10-18/out-of-hours'
+                )
+              })
+          })
+        })
+
+        cy.audit()
+      })
+    })
+
+    describe('Search for an overtime work order', () => {
+      beforeEach(() => {
+        cy.visit('/search')
+
+        cy.get('#formView_workOrder').click()
+        cy.get('#workOrderSearch').clear()
+      })
+
+      it('Displays a list of work orders', () => {
+        cy.intercept(
+          { method: 'GET', path: '/api/v1/work/elements?query=12345678' },
+          { statusCode: 200, fixture: 'search/work_elements/overtime.json' }
+        ).as('get_work_elements')
+
+        cy.get('#workOrderSearch').type('12345678')
+        cy.get('button').click()
+
+        cy.wait('@get_work_elements')
+        cy.contains('We found 1 matching result for: 12345678')
+
+        cy.get('table').within(() => {
+          cy.get('thead > tr:nth-child(1)').within(() => {
+            cy.get(':nth-child(1)').contains('Operative name')
+            cy.get(':nth-child(2)').contains('Payroll no.')
+            cy.get(':nth-child(3)').contains('Work order')
+            cy.get(':nth-child(4)').contains('Property')
+            cy.get(':nth-child(5)').contains('Close date')
+            cy.get(':nth-child(6)').contains('Value')
+            cy.get(':nth-child(7)').contains('Period')
+            cy.get(':nth-child(8)').contains('Week')
+          })
+
+          cy.get('tbody > tr:nth-child(1)').within(() => {
+            cy.get(':nth-child(1)')
+              .contains('a', 'Alex Cable')
+              .should((link) => {
+                expect(link).to.have.attr('href', '/operatives/123456')
+              })
+            cy.get(':nth-child(2)')
+              .contains('a', '123456')
+              .should((link) => {
+                expect(link).to.have.attr('href', '/operatives/123456')
+              })
+            cy.get(':nth-child(3)')
+              .contains('a', '12345678')
+              .should((link) => {
+                expect(link).to.have.attr(
+                  'href',
+                  'https://repairs-hub.hackney.gov.uk/work-orders/12345678'
+                )
+                expect(link).to.have.attr('target', '_blank')
+              })
+            cy.get(':nth-child(4)').contains('2 Somewhere Street')
+            cy.get(':nth-child(5)').contains('19/10/2021')
+            cy.get(':nth-child(6)').contains('£21.60')
+            cy.get(':nth-child(7)')
+              .contains('a', '3')
+              .should((link) => {
+                expect(link).to.have.attr(
+                  'href',
+                  '/operatives/123456/summaries/2021-08-02'
+                )
+              })
+            cy.get(':nth-child(8)')
+              .contains('a', '12')
+              .should((link) => {
+                expect(link).to.have.attr(
+                  'href',
+                  '/operatives/123456/timesheets/2021-10-18/overtime'
                 )
               })
           })

--- a/src/components/CombinedSearch/WorkOrderSearch.js
+++ b/src/components/CombinedSearch/WorkOrderSearch.js
@@ -5,8 +5,6 @@ import Spinner from '@/components/Spinner'
 import { useState, useRef } from 'react'
 import { Table, THead, TBody, TR, TH, TD } from '@/components/Table'
 import { findWorkElements } from '@/utils/apiClient'
-import { numberWithPrecision } from '@/utils/number'
-import { smvh } from '@/utils/scheme'
 
 const WorkOrderSearch = () => {
   const repairsHubUrl = process.env.NEXT_PUBLIC_REPAIRS_HUB_URL
@@ -103,7 +101,7 @@ const WorkOrderSearch = () => {
                       Close date
                     </TH>
                     <TH scope="col" numeric={true}>
-                      SMVh
+                      Value
                     </TH>
                     <TH scope="col" align="centre">
                       Period
@@ -144,9 +142,7 @@ const WorkOrderSearch = () => {
                       </TD>
                       <TD>{workElement.address}</TD>
                       <TD align="centre">{workElement.closedDate}</TD>
-                      <TD numeric={true}>
-                        {numberWithPrecision(smvh(workElement.value), 2)}
-                      </TD>
+                      <TD numeric={true}>{workElement.formattedValue}</TD>
                       <TD align="centre">
                         <Link href={workElement.summaryUrl}>
                           <a className="lbh-link lbh-link--no-visited-state">

--- a/src/models/WorkElement.js
+++ b/src/models/WorkElement.js
@@ -1,6 +1,8 @@
 import PayElementType from './PayElementType'
 import Week from './Week'
 import dayjs from '@/utils/date'
+import { numberWithPrecision } from '@/utils/number'
+import { smvh } from '@/utils/scheme'
 
 export default class WorkElement {
   constructor(attrs) {
@@ -44,5 +46,13 @@ export default class WorkElement {
 
   get summaryUrl() {
     return `${this.baseUrl}/summaries/${this.week.bonusPeriod.id}`
+  }
+
+  get formattedValue() {
+    if (this.isOutOfHours || this.isOvertime) {
+      return `£${numberWithPrecision(this.value, 2)}`
+    } else {
+      return numberWithPrecision(smvh(this.value), 2)
+    }
   }
 }


### PR DESCRIPTION
It's confusing to display the money value of this jobs as SMVs since they get converted to hour values (i.e. divided by 60). Instead change the header to say 'Value' and display either SMVs or £X.XX values.

![image](https://user-images.githubusercontent.com/6321/158538321-9358541a-58f5-41f4-9ea8-8a5e854a9a5e.png)
