### PR TITLE
Filter out archived operatives when closing a week

### DIFF
--- a/cypress/fixtures/weeks/2021-08-02.json
+++ b/cypress/fixtures/weeks/2021-08-02.json
@@ -21,13 +21,33 @@
         "description": "Electrician"
       },
       "schemeId": 2,
+      "isArchived": false,
       "productiveValue": 0.0,
       "nonProductiveDuration": 0,
       "nonProductiveValue": 0,
       "totalValue": 0,
       "utilisation": 1,
       "projectedValue": 0,
-      "averageUtilisation": 1
+      "averageUtilisation": 1,
+      "reportSentAt": null
+    },
+    {
+      "id": "654321",
+      "name": "André Wood",
+      "trade": {
+        "id": "CP",
+        "description": "Carpenter"
+      },
+      "schemeId": 2,
+      "isArchived": true,
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 0.0,
+      "nonProductiveValue": 0.0,
+      "totalValue": 0.0,
+      "utilisation": 1,
+      "projectedValue": 0.0,
+      "averageUtilisation": 1,
+      "reportSentAt": null
     }
   ]
 }

--- a/cypress/fixtures/weeks/2021-08-09.json
+++ b/cypress/fixtures/weeks/2021-08-09.json
@@ -21,13 +21,33 @@
         "description": "Electrician"
       },
       "schemeId": 2,
+      "isArchived": false,
       "productiveValue": 0.0,
       "nonProductiveDuration": 0,
       "nonProductiveValue": 0,
       "totalValue": 0,
       "utilisation": 1,
       "projectedValue": 0,
-      "averageUtilisation": 1
+      "averageUtilisation": 1,
+      "reportSentAt": null
+    },
+    {
+      "id": "654321",
+      "name": "André Wood",
+      "trade": {
+        "id": "CP",
+        "description": "Carpenter"
+      },
+      "schemeId": 2,
+      "isArchived": true,
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 0.0,
+      "nonProductiveValue": 0.0,
+      "totalValue": 0.0,
+      "utilisation": 1,
+      "projectedValue": 0.0,
+      "averageUtilisation": 1,
+      "reportSentAt": null
     }
   ]
 }

--- a/cypress/fixtures/weeks/2021-08-16.json
+++ b/cypress/fixtures/weeks/2021-08-16.json
@@ -21,13 +21,33 @@
         "description": "Electrician"
       },
       "schemeId": 2,
+      "isArchived": false,
       "productiveValue": 0.0,
       "nonProductiveDuration": 0,
       "nonProductiveValue": 0,
       "totalValue": 0,
       "utilisation": 1,
       "projectedValue": 0,
-      "averageUtilisation": 1
+      "averageUtilisation": 1,
+      "reportSentAt": null
+    },
+    {
+      "id": "654321",
+      "name": "André Wood",
+      "trade": {
+        "id": "CP",
+        "description": "Carpenter"
+      },
+      "schemeId": 2,
+      "isArchived": true,
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 0.0,
+      "nonProductiveValue": 0.0,
+      "totalValue": 0.0,
+      "utilisation": 1,
+      "projectedValue": 0.0,
+      "averageUtilisation": 1,
+      "reportSentAt": null
     }
   ]
 }

--- a/cypress/fixtures/weeks/2021-08-23.json
+++ b/cypress/fixtures/weeks/2021-08-23.json
@@ -21,13 +21,33 @@
         "description": "Electrician"
       },
       "schemeId": 2,
+      "isArchived": false,
       "productiveValue": 0.0,
       "nonProductiveDuration": 0,
       "nonProductiveValue": 0,
       "totalValue": 0,
       "utilisation": 1,
       "projectedValue": 0,
-      "averageUtilisation": 1
+      "averageUtilisation": 1,
+      "reportSentAt": null
+    },
+    {
+      "id": "654321",
+      "name": "André Wood",
+      "trade": {
+        "id": "CP",
+        "description": "Carpenter"
+      },
+      "schemeId": 2,
+      "isArchived": true,
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 0.0,
+      "nonProductiveValue": 0.0,
+      "totalValue": 0.0,
+      "utilisation": 1,
+      "projectedValue": 0.0,
+      "averageUtilisation": 1,
+      "reportSentAt": null
     }
   ]
 }

--- a/cypress/fixtures/weeks/2021-08-30.json
+++ b/cypress/fixtures/weeks/2021-08-30.json
@@ -21,13 +21,33 @@
         "description": "Electrician"
       },
       "schemeId": 2,
+      "isArchived": false,
       "productiveValue": 0.0,
       "nonProductiveDuration": 0,
       "nonProductiveValue": 0,
       "totalValue": 0,
       "utilisation": 1,
       "projectedValue": 0,
-      "averageUtilisation": 1
+      "averageUtilisation": 1,
+      "reportSentAt": null
+    },
+    {
+      "id": "654321",
+      "name": "André Wood",
+      "trade": {
+        "id": "CP",
+        "description": "Carpenter"
+      },
+      "schemeId": 2,
+      "isArchived": true,
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 0.0,
+      "nonProductiveValue": 0.0,
+      "totalValue": 0.0,
+      "utilisation": 1,
+      "projectedValue": 0.0,
+      "averageUtilisation": 1,
+      "reportSentAt": null
     }
   ]
 }

--- a/cypress/fixtures/weeks/2021-09-06.json
+++ b/cypress/fixtures/weeks/2021-09-06.json
@@ -21,13 +21,33 @@
         "description": "Electrician"
       },
       "schemeId": 2,
+      "isArchived": false,
       "productiveValue": 0.0,
       "nonProductiveDuration": 0,
       "nonProductiveValue": 0,
       "totalValue": 0,
       "utilisation": 1,
       "projectedValue": 0,
-      "averageUtilisation": 1
+      "averageUtilisation": 1,
+      "reportSentAt": null
+    },
+    {
+      "id": "654321",
+      "name": "André Wood",
+      "trade": {
+        "id": "CP",
+        "description": "Carpenter"
+      },
+      "schemeId": 2,
+      "isArchived": true,
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 0.0,
+      "nonProductiveValue": 0.0,
+      "totalValue": 0.0,
+      "utilisation": 1,
+      "projectedValue": 0.0,
+      "averageUtilisation": 1,
+      "reportSentAt": null
     }
   ]
 }

--- a/cypress/fixtures/weeks/2021-09-13.json
+++ b/cypress/fixtures/weeks/2021-09-13.json
@@ -21,13 +21,33 @@
         "description": "Electrician"
       },
       "schemeId": 2,
+      "isArchived": false,
       "productiveValue": 0.0,
       "nonProductiveDuration": 0,
       "nonProductiveValue": 0,
       "totalValue": 0,
       "utilisation": 1,
       "projectedValue": 0,
-      "averageUtilisation": 1
+      "averageUtilisation": 1,
+      "reportSentAt": null
+    },
+    {
+      "id": "654321",
+      "name": "André Wood",
+      "trade": {
+        "id": "CP",
+        "description": "Carpenter"
+      },
+      "schemeId": 2,
+      "isArchived": true,
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 0.0,
+      "nonProductiveValue": 0.0,
+      "totalValue": 0.0,
+      "utilisation": 1,
+      "projectedValue": 0.0,
+      "averageUtilisation": 1,
+      "reportSentAt": null
     }
   ]
 }

--- a/cypress/fixtures/weeks/2021-09-20.json
+++ b/cypress/fixtures/weeks/2021-09-20.json
@@ -21,13 +21,33 @@
         "description": "Electrician"
       },
       "schemeId": 2,
+      "isArchived": false,
       "productiveValue": 0.0,
       "nonProductiveDuration": 0,
       "nonProductiveValue": 0,
       "totalValue": 0,
       "utilisation": 1,
       "projectedValue": 0,
-      "averageUtilisation": 1
+      "averageUtilisation": 1,
+      "reportSentAt": null
+    },
+    {
+      "id": "654321",
+      "name": "André Wood",
+      "trade": {
+        "id": "CP",
+        "description": "Carpenter"
+      },
+      "schemeId": 2,
+      "isArchived": true,
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 0.0,
+      "nonProductiveValue": 0.0,
+      "totalValue": 0.0,
+      "utilisation": 1,
+      "projectedValue": 0.0,
+      "averageUtilisation": 1,
+      "reportSentAt": null
     }
   ]
 }

--- a/cypress/fixtures/weeks/2021-09-27.json
+++ b/cypress/fixtures/weeks/2021-09-27.json
@@ -21,13 +21,33 @@
         "description": "Electrician"
       },
       "schemeId": 2,
+      "isArchived": false,
       "productiveValue": 0.0,
       "nonProductiveDuration": 0,
       "nonProductiveValue": 0,
       "totalValue": 0,
       "utilisation": 1,
       "projectedValue": 0,
-      "averageUtilisation": 1
+      "averageUtilisation": 1,
+      "reportSentAt": null
+    },
+    {
+      "id": "654321",
+      "name": "André Wood",
+      "trade": {
+        "id": "CP",
+        "description": "Carpenter"
+      },
+      "schemeId": 2,
+      "isArchived": true,
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 0.0,
+      "nonProductiveValue": 0.0,
+      "totalValue": 0.0,
+      "utilisation": 1,
+      "projectedValue": 0.0,
+      "averageUtilisation": 1,
+      "reportSentAt": null
     }
   ]
 }

--- a/cypress/fixtures/weeks/2021-10-04.json
+++ b/cypress/fixtures/weeks/2021-10-04.json
@@ -21,13 +21,33 @@
         "description": "Electrician"
       },
       "schemeId": 2,
+      "isArchived": false,
       "productiveValue": 0.0,
       "nonProductiveDuration": 0,
       "nonProductiveValue": 0,
       "totalValue": 0,
       "utilisation": 1,
       "projectedValue": 0,
-      "averageUtilisation": 1
+      "averageUtilisation": 1,
+      "reportSentAt": null
+    },
+    {
+      "id": "654321",
+      "name": "André Wood",
+      "trade": {
+        "id": "CP",
+        "description": "Carpenter"
+      },
+      "schemeId": 2,
+      "isArchived": true,
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 0.0,
+      "nonProductiveValue": 0.0,
+      "totalValue": 0.0,
+      "utilisation": 1,
+      "projectedValue": 0.0,
+      "averageUtilisation": 1,
+      "reportSentAt": null
     }
   ]
 }

--- a/cypress/fixtures/weeks/2021-10-11.json
+++ b/cypress/fixtures/weeks/2021-10-11.json
@@ -21,13 +21,33 @@
         "description": "Electrician"
       },
       "schemeId": 2,
+      "isArchived": false,
       "productiveValue": 0.0,
       "nonProductiveDuration": 0,
       "nonProductiveValue": 0,
       "totalValue": 0,
       "utilisation": 1,
       "projectedValue": 0,
-      "averageUtilisation": 1
+      "averageUtilisation": 1,
+      "reportSentAt": null
+    },
+    {
+      "id": "654321",
+      "name": "André Wood",
+      "trade": {
+        "id": "CP",
+        "description": "Carpenter"
+      },
+      "schemeId": 2,
+      "isArchived": true,
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 0.0,
+      "nonProductiveValue": 0.0,
+      "totalValue": 0.0,
+      "utilisation": 1,
+      "projectedValue": 0.0,
+      "averageUtilisation": 1,
+      "reportSentAt": null
     }
   ]
 }

--- a/cypress/fixtures/weeks/2021-10-18-closed-and-sent.json
+++ b/cypress/fixtures/weeks/2021-10-18-closed-and-sent.json
@@ -21,13 +21,33 @@
         "description": "Electrician"
       },
       "schemeId": 2,
+      "isArchived": false,
       "productiveValue": 0.0,
       "nonProductiveDuration": 36.0,
       "nonProductiveValue": 3672.0,
       "totalValue": 3672.0,
       "utilisation": 1,
       "projectedValue": 2636.35,
-      "averageUtilisation": 1
+      "averageUtilisation": 1,
+      "reportSentAt": "2021-10-29T16:05:00Z"
+    },
+    {
+      "id": "654321",
+      "name": "André Wood",
+      "trade": {
+        "id": "CP",
+        "description": "Carpenter"
+      },
+      "schemeId": 2,
+      "isArchived": true,
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 0.0,
+      "nonProductiveValue": 0.0,
+      "totalValue": 0.0,
+      "utilisation": 1,
+      "projectedValue": 0.0,
+      "averageUtilisation": 1,
+      "reportSentAt": null
     }
   ]
 }

--- a/cypress/fixtures/weeks/2021-10-18-closed.json
+++ b/cypress/fixtures/weeks/2021-10-18-closed.json
@@ -21,13 +21,33 @@
         "description": "Electrician"
       },
       "schemeId": 2,
+      "isArchived": false,
       "productiveValue": 0.0,
       "nonProductiveDuration": 36.0,
       "nonProductiveValue": 3672.0,
       "totalValue": 3672.0,
       "utilisation": 1,
       "projectedValue": 2636.35,
-      "averageUtilisation": 1
+      "averageUtilisation": 1,
+      "reportSentAt": null
+    },
+    {
+      "id": "654321",
+      "name": "André Wood",
+      "trade": {
+        "id": "CP",
+        "description": "Carpenter"
+      },
+      "schemeId": 2,
+      "isArchived": true,
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 0.0,
+      "nonProductiveValue": 0.0,
+      "totalValue": 0.0,
+      "utilisation": 1,
+      "projectedValue": 0.0,
+      "averageUtilisation": 1,
+      "reportSentAt": null
     }
   ]
 }

--- a/cypress/fixtures/weeks/2021-10-18.json
+++ b/cypress/fixtures/weeks/2021-10-18.json
@@ -27,7 +27,26 @@
       "totalValue": 3672.0,
       "utilisation": 1,
       "projectedValue": 2636.35,
-      "averageUtilisation": 1
+      "averageUtilisation": 1,
+      "reportSentAt": null
+    },
+    {
+      "id": "654321",
+      "name": "André Wood",
+      "trade": {
+        "id": "CP",
+        "description": "Carpenter"
+      },
+      "schemeId": 2,
+      "isArchived": true,
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 0.0,
+      "nonProductiveValue": 0.0,
+      "totalValue": 0.0,
+      "utilisation": 1,
+      "projectedValue": 0.0,
+      "averageUtilisation": 1,
+      "reportSentAt": null
     }
   ]
 }

--- a/cypress/fixtures/weeks/2021-10-25.json
+++ b/cypress/fixtures/weeks/2021-10-25.json
@@ -27,7 +27,26 @@
       "totalValue": 8458.8,
       "utilisation": 1,
       "projectedValue": 3084.23,
-      "averageUtilisation": 1
+      "averageUtilisation": 1,
+      "reportSentAt": null
+    },
+    {
+      "id": "654321",
+      "name": "André Wood",
+      "trade": {
+        "id": "CP",
+        "description": "Carpenter"
+      },
+      "schemeId": 2,
+      "isArchived": true,
+      "productiveValue": 0.0,
+      "nonProductiveDuration": 0.0,
+      "nonProductiveValue": 0.0,
+      "totalValue": 0.0,
+      "utilisation": 1,
+      "projectedValue": 0.0,
+      "averageUtilisation": 1,
+      "reportSentAt": null
     }
   ]
 }

--- a/cypress/integration/closing-a-week.spec.js
+++ b/cypress/integration/closing-a-week.spec.js
@@ -216,6 +216,7 @@ describe('Closing a week', () => {
       cy.get('.bc-open-weeks__period:nth-of-type(1)').within(() => {
         cy.get('.bc-open-weeks__week:nth-of-type(1)').within(() => {
           cy.get('header').within(() => {
+            cy.contains('h4', 'Operatives with no SMVs (0)')
             cy.contains('a', 'Close week and send reports').click()
 
             cy.location().should((loc) => {
@@ -335,6 +336,9 @@ describe('Closing a week', () => {
       cy.get('.bc-all-operatives').within(() => {
         cy.contains('h1', 'Period 3 – 2021 / week 13')
         cy.contains('p', 'All operatives')
+
+        cy.get('tbody tr:nth-child(1)').contains('td:first-child', 'Alex Cable')
+        cy.get('tbody tr:nth-child(2)').should('not.exist')
       })
 
       cy.get('.lbh-page-announcement').should('not.exist')

--- a/src/components/AllOperativesList/index.js
+++ b/src/components/AllOperativesList/index.js
@@ -22,11 +22,11 @@ const Header = ({ week }) => {
 }
 
 const Search = ({ week }) => {
-  const allOperatives = week.operativeSummaries
+  const allOperatives = week.operatives
   const searchInput = useRef(null)
 
   const [value, setValue] = useState('')
-  const [operatives, setOperatives] = useState(week.operativeSummaries)
+  const [operatives, setOperatives] = useState(week.operatives)
 
   const filterOperatives = (filter) => {
     if (filter) {
@@ -216,8 +216,8 @@ const Operatives = ({ week, operatives }) => {
 }
 
 const AllOperativesList = ({ period, week, schemes }) => {
-  week.operativeSummaries.forEach((os) => {
-    os.scheme = schemes[os.schemeId]
+  week.operatives.forEach((o) => {
+    o.scheme = schemes[o.schemeId]
   })
 
   const firstOpenWeek = period.weeks.find((week) => week.isEditable)

--- a/src/components/CloseWeek/index.js
+++ b/src/components/CloseWeek/index.js
@@ -15,7 +15,7 @@ import {
 } from '@/utils/apiClient'
 
 const Summary = ({ week }) => {
-  const operatives = week.operativeSummaries
+  const operatives = week.operatives
   const zeroSMVOperatives = operatives.filter((o) => o.totalValue == 0)
 
   return (
@@ -78,7 +78,7 @@ const CloseWeek = ({ week }) => {
   const { setAnnouncement } = useContext(AnnouncementContext)
 
   const sendReports = async () => {
-    for (const operative of week.operativeSummaries) {
+    for (const operative of week.operatives) {
       if (!operative.reportSentAt) {
         if (await sendReportEmail(operative.id, week.bonusPeriod.id)) {
           if (await saveReportSentAt(operative.id, week.id)) {

--- a/src/components/ManageBonusPeriod/index.js
+++ b/src/components/ManageBonusPeriod/index.js
@@ -94,9 +94,7 @@ const OperativeList = ({ date }) => {
 
   useEffect(() => {
     if (week && !allOperatives) {
-      setAllOperatives(
-        week.operativeSummaries.filter((os) => os.totalValue == 0)
-      )
+      setAllOperatives(week.operatives.filter((os) => os.totalValue == 0))
     }
   }, [isLoading, allOperatives, week])
 

--- a/src/models/OperativeSummary.js
+++ b/src/models/OperativeSummary.js
@@ -8,6 +8,7 @@ export default class OperativeSummary {
     this.name = attrs.name
     this.trade = new Trade(attrs.trade)
     this.schemeId = attrs.schemeId
+    this.isArchived = attrs.isArchived
     this.productiveValue = attrs.productiveValue
     this.nonProductiveDuration = attrs.nonProductiveDuration
     this.nonProductiveValue = attrs.nonProductiveValue

--- a/src/models/Week.js
+++ b/src/models/Week.js
@@ -164,12 +164,16 @@ export default class Week {
     return !this.isCompleted && (this.isCurrent || this.isPast)
   }
 
+  get operatives() {
+    return this.operativeSummaries.filter((os) => !os.isArchived)
+  }
+
   get operativeCount() {
-    return this.operativeSummaries.length
+    return this.operatives.length
   }
 
   get sentOperatives() {
-    return this.operativeSummaries.filter((os) => os.reportSentAt)
+    return this.operatives.filter((os) => os.reportSentAt)
   }
 
   get sentOperativeCount() {


### PR DESCRIPTION
When an operative has been archived they will always have zero SMVs for a week until the end of the bonus period at which point they're not added to the next period. Since this is confusing and time-wasting since it has to be checked then filter them out specifically during the closing of the week.
