### PR TITLE
Allow week managers to edit closed weeks

### DIFF
--- a/src/components/NonProductiveSummary/index.js
+++ b/src/components/NonProductiveSummary/index.js
@@ -5,10 +5,14 @@ import ButtonGroup from '@/components/ButtonGroup'
 import ButtonLink from '@/components/ButtonLink'
 import PageContext from '@/components/PageContext'
 import Pagination from '@/components/Pagination'
+import UserContext from '@/components/UserContext'
+import { isEditable } from '@/utils/auth'
 import { generateWeeklyReport } from '@/utils/reports'
 import { useContext } from 'react'
 
 const NonProductiveSummary = () => {
+  const { user } = useContext(UserContext)
+
   const {
     operative,
     timesheet,
@@ -37,7 +41,7 @@ const NonProductiveSummary = () => {
       <ButtonGroup>
         <Button onClick={downloadReport}>Download report</Button>
 
-        {week.isEditable && operative.isEditable && (
+        {isEditable(operative, week, bonusPeriod, user) && (
           <ButtonLink href={`${baseUrl}/non-productive/edit`} secondary={true}>
             Edit non-productive
           </ButtonLink>

--- a/src/components/OutOfHoursSummary/index.js
+++ b/src/components/OutOfHoursSummary/index.js
@@ -6,10 +6,14 @@ import ButtonGroup from '@/components/ButtonGroup'
 import ButtonLink from '@/components/ButtonLink'
 import PageContext from '@/components/PageContext'
 import Pagination from '@/components/Pagination'
+import UserContext from '@/components/UserContext'
+import { isEditable } from '@/utils/auth'
 import { generateOutOfHoursReport } from '@/utils/reports'
 import { useContext } from 'react'
 
 const OutOfHoursSummary = () => {
+  const { user } = useContext(UserContext)
+
   const {
     operative,
     timesheet,
@@ -38,7 +42,7 @@ const OutOfHoursSummary = () => {
       <ButtonGroup>
         <Button onClick={downloadReport}>Download report</Button>
 
-        {week.isEditable && operative.isEditable && (
+        {isEditable(operative, week, bonusPeriod, user) && (
           <ButtonLink href={`${baseUrl}/out-of-hours/edit`} secondary={true}>
             Edit out of hours
           </ButtonLink>

--- a/src/components/OvertimeSummary/index.js
+++ b/src/components/OvertimeSummary/index.js
@@ -7,10 +7,14 @@ import ButtonGroup from '@/components/ButtonGroup'
 import ButtonLink from '@/components/ButtonLink'
 import PageContext from '@/components/PageContext'
 import Pagination from '@/components/Pagination'
+import UserContext from '@/components/UserContext'
+import { isEditable } from '@/utils/auth'
 import { generateOvertimeReport } from '@/utils/reports'
 import { useContext } from 'react'
 
 const OvertimeSummary = () => {
+  const { user } = useContext(UserContext)
+
   const {
     operative,
     timesheet,
@@ -49,7 +53,7 @@ const OvertimeSummary = () => {
       <ButtonGroup>
         <Button onClick={downloadReport}>Download report</Button>
 
-        {week.isEditable && operative.isEditable && (
+        {isEditable(operative, week, bonusPeriod, user) && (
           <ButtonLink href={`${baseUrl}/overtime/edit`} secondary={true}>
             Edit overtime
           </ButtonLink>

--- a/src/components/ProductiveSummary/index.js
+++ b/src/components/ProductiveSummary/index.js
@@ -7,10 +7,14 @@ import ButtonGroup from '@/components/ButtonGroup'
 import ButtonLink from '@/components/ButtonLink'
 import PageContext from '@/components/PageContext'
 import Pagination from '@/components/Pagination'
+import UserContext from '@/components/UserContext'
+import { isEditable } from '@/utils/auth'
 import { generateWeeklyReport } from '@/utils/reports'
 import { useContext } from 'react'
 
 const ProductiveSummary = () => {
+  const { user } = useContext(UserContext)
+
   const {
     operative,
     timesheet,
@@ -50,7 +54,7 @@ const ProductiveSummary = () => {
       <ButtonGroup>
         <Button onClick={downloadReport}>Download report</Button>
 
-        {week.isEditable && operative.isEditable && (
+        {isEditable(operative, week, bonusPeriod, user) && (
           <ButtonLink href={`${baseUrl}/productive/edit`} secondary={true}>
             Edit productive
           </ButtonLink>

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,11 @@
+export const isEditable = (operative, week, period, user) => {
+  if (operative.isArchived || period.isClosed) {
+    return false
+  }
+
+  if (user.hasWeekManagerPermissions) {
+    return true
+  }
+
+  return week.isEditable
+}

--- a/src/utils/auth.test.js
+++ b/src/utils/auth.test.js
@@ -1,0 +1,64 @@
+import { isEditable } from './auth'
+
+describe('isEditable', () => {
+  describe('when the operative is archived', () => {
+    const operative = { isArchived: true }
+
+    test('returns false', () => {
+      const week = { isEditable: true }
+      const period = { isClosed: false }
+      const user = { hasWeekManagerPermissions: false }
+
+      expect(isEditable(operative, week, period, user)).toBe(false)
+    })
+  })
+
+  describe('when the operative is not archived', () => {
+    const operative = { isArchived: false }
+
+    describe('when the period is closed', () => {
+      const period = { isClosed: true }
+
+      test('returns false', () => {
+        const week = { isEditable: true }
+        const user = { hasWeekManagerPermissions: false }
+
+        expect(isEditable(operative, week, period, user)).toBe(false)
+      })
+    })
+
+    describe('when the period is open', () => {
+      const period = { isClosed: false }
+
+      describe('when the week is open', () => {
+        const week = { isEditable: true }
+
+        test('returns true', () => {
+          const user = { hasWeekManagerPermissions: false }
+
+          expect(isEditable(operative, week, period, user)).toBe(true)
+        })
+      })
+
+      describe('when the week is closed', () => {
+        const week = { isEditable: false }
+
+        describe('when the user is not a week manager', () => {
+          const user = { hasWeekManagerPermissions: false }
+
+          test('returns false', () => {
+            expect(isEditable(operative, week, period, user)).toBe(false)
+          })
+        })
+
+        describe('when the user is a week manager', () => {
+          const user = { hasWeekManagerPermissions: true }
+
+          test('returns true', () => {
+            expect(isEditable(operative, week, period, user)).toBe(true)
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
We get multiple requests to edit pay elements in previous weeks once operatives receive reports. Rather than allowing negative elements in future weeks, allow users with week manager permissions to edit them until a period is closed.
