### PR TITLE
Filter out operatives who have zero SMVs but have had time entered

### DIFF
--- a/src/components/CloseWeek/index.js
+++ b/src/components/CloseWeek/index.js
@@ -16,7 +16,7 @@ import {
 
 const Summary = ({ week }) => {
   const operatives = week.operatives
-  const zeroSMVOperatives = operatives.filter((o) => o.totalValue == 0)
+  const zeroSMVOperatives = operatives.filter((o) => o.hasZeroSMVs)
 
   return (
     <div className="bc-close-week__summary">

--- a/src/components/ManageBonusPeriod/index.js
+++ b/src/components/ManageBonusPeriod/index.js
@@ -95,7 +95,7 @@ const OperativeList = ({ date }) => {
 
   useEffect(() => {
     if (week && !allOperatives) {
-      setAllOperatives(week.operatives.filter((os) => os.totalValue == 0))
+      setAllOperatives(week.operatives.filter((os) => os.hasZeroSMVs))
     }
   }, [isLoading, allOperatives, week])
 

--- a/src/models/OperativeSummary.js
+++ b/src/models/OperativeSummary.js
@@ -39,6 +39,14 @@ export default class OperativeSummary {
     return this.payBandFor(this.projectedValue, this.averageUtilisation)
   }
 
+  get hasNonProductiveDuration() {
+    return this.nonProductiveDuration > 0
+  }
+
+  get hasZeroSMVs() {
+    return this.totalValue == 0 && !this.hasNonProductiveDuration
+  }
+
   payBandFor(value, utilisation) {
     return bandForValue(this.scheme.payBands, value, utilisation)
   }


### PR DESCRIPTION
Brian wants to record the non-working days of part time operatives but to stop them appearing in the 'Operatives with no SMVs' section we need to filter them out based on whether they have had any time recorded.