### PR TITLE
Trigger the development environment ... retiring.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - store_artifacts:
           path: cypress/reports
 
-  build-deploy-development:
+  nuke-development:
     executor: aws-cli/default
     steps:
       - *attach_workspace
@@ -87,8 +87,9 @@ jobs:
             echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
       - run:
-          name: deploy
+          name: nuke
           command: |
+            set -e
             export NODE_ENV=production
             export NEXT_PUBLIC_NODE_ENV=production
             export NEXT_PUBLIC_ENV_NAME=development
@@ -103,7 +104,8 @@ jobs:
             export NEXT_PUBLIC_SENTRY_ENVIRONMENT=development
             export NEXT_PUBLIC_SENTRY_RELEASE=$CIRCLE_SHA1
             export NEXT_PUBLIC_SENTRY_DEBUG=false
-            yarn build && yarn --production=true && npm i --prefix=$HOME/.local -g serverless@"<3.0.0" && sls deploy -s development
+            npm i --prefix=$HOME/.local -g serverless@"<3.0.0"
+            sls remove -s development
 
   build-deploy-staging:
     executor: aws-cli/default
@@ -233,7 +235,7 @@ workflows:
           filters:
             branches:
               only: develop
-      - build-deploy-development:
+      - nuke-development:
           requires:
             - assume-role-development
           filters:


### PR DESCRIPTION
# What:
 - Trigger the development environment resource destruction.

# Why:
 - The development environment retirement process has started long ago with this [commit](https://github.com/LBHackney-IT/bonuscalc-api/commit/d9629988d2c1dcb0e4e3126395da3cdad9818596).
 - The `development` database is going to get retired soon after.