### PR TITLE
Clean up development environment references.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,9 +229,6 @@ workflows:
             - install-dependencies
       - assume-role-development:
           context: api-assume-role-housing-development-context
-          requires:
-            - tests
-            - e2e
           filters:
             branches:
               only: develop


### PR DESCRIPTION
# What:
 - Remove `development` workflow steps from the main pipeline workflow.

# Why:
 - The environment is getting retired, see this [commit](https://github.com/LBHackney-IT/bonuscalc-api/commit/d9629988d2c1dcb0e4e3126395da3cdad9818596), and this PR #127.