### PR TITLE
Fix add note bug

### DIFF
--- a/src/components/MoneyForm/index.js
+++ b/src/components/MoneyForm/index.js
@@ -42,6 +42,8 @@ const NoteField = ({ item, index }) => {
   }
 
   const addNote = (event) => {
+    event.preventDefault()
+
     setInput(event.target.nextElementSibling)
     setShowNote(true)
   }

--- a/src/components/PayElementsForm/index.js
+++ b/src/components/PayElementsForm/index.js
@@ -63,6 +63,8 @@ const NoteField = ({ item, index }) => {
   }
 
   const addNote = (event) => {
+    event.preventDefault()
+
     setInput(event.target.nextElementSibling)
     setShowNote(true)
   }
@@ -270,6 +272,9 @@ const PayElementsForm = ({
   useEffect(() => {
     if (!initialized) {
       append(payElements.map((pe) => pe.toRow(2)))
+      // Append creates duplicates locally with strict mode enabled. this could fix it
+      // replace(payElements.map((pe) => pe.toRow(2)))
+
       setInitialized(true)
     }
   }, [append, payElements, initialized])


### PR DESCRIPTION
The recent NextJs upgrade seems to have caused the following bug:

When user clicks the "Add note" button, they should see a text field appear. But instead, the button submits the form. This prevents the user from adding a note.

<img width="1258" height="713" alt="image" src="https://github.com/user-attachments/assets/6f2acfe5-b825-47ea-bd1a-03baf1a644ac" />
