### PR TITLE
Fix broken default types

### DIFF
--- a/src/components/EditOvertime/OvertimeForm.js
+++ b/src/components/EditOvertime/OvertimeForm.js
@@ -205,7 +205,7 @@ const OvertimeForm = ({ onSubmit, appendLabel, children, rate }) => {
                     <DurationField index={index} />
                   </TD>
                   <TD align="right">
-                    <LinkButton onClick={() => remove(index)}>
+                    <LinkButton type="button" onClick={() => remove(index)}>
                       Remove
                     </LinkButton>
                   </TD>

--- a/src/components/MoneyForm/index.js
+++ b/src/components/MoneyForm/index.js
@@ -42,8 +42,6 @@ const NoteField = ({ item, index }) => {
   }
 
   const addNote = (event) => {
-    event.preventDefault()
-
     setInput(event.target.nextElementSibling)
     setShowNote(true)
   }
@@ -60,6 +58,7 @@ const NoteField = ({ item, index }) => {
           showNote ? 'govuk-!-display-none' : null
         )}
         onClick={addNote}
+        type="button"
       >
         Add note
       </LinkButton>

--- a/src/components/PayElementsForm/index.js
+++ b/src/components/PayElementsForm/index.js
@@ -63,8 +63,6 @@ const NoteField = ({ item, index }) => {
   }
 
   const addNote = (event) => {
-    event.preventDefault()
-
     setInput(event.target.nextElementSibling)
     setShowNote(true)
   }
@@ -81,6 +79,7 @@ const NoteField = ({ item, index }) => {
           showNote ? 'govuk-!-display-none' : null
         )}
         onClick={addNote}
+        type="button"
       >
         Add note
       </LinkButton>
@@ -393,7 +392,7 @@ const PayElementsForm = ({
                     />
                   </TD>
                   <TD>
-                    <LinkButton onClick={() => remove(index)}>
+                    <LinkButton type="button" onClick={() => remove(index)}>
                       Remove
                     </LinkButton>
                   </TD>


### PR DESCRIPTION
### Description of change

[Previous PR](https://github.com/LBHackney-IT/bonuscalc-frontend/pull/152)

Turns out, the issue has been due to default props not working correctly. When pressing return within the text field, it triggers the remove button. Changing the button type to button resolves this issue. Also negating the need for prevent.default()

<img width="1112" height="652" alt="image" src="https://github.com/user-attachments/assets/4b7e39d0-c8a1-42c1-ba82-2eba3572b9a7" />
